### PR TITLE
Add SF Symbols to menu commands and improve UI

### DIFF
--- a/BitDream/BitDreamApp.swift
+++ b/BitDream/BitDreamApp.swift
@@ -493,11 +493,11 @@ struct BitDreamApp: App {
             SidebarCommands()
             CommandGroup(before: .sidebar) {
                 Divider()
-                Menu("Appearance") {
+                Menu {
                     Picker("Appearance", selection: $themeManager.themeMode) {
-                        Text("System").tag(ThemeMode.system)
-                        Text("Light").tag(ThemeMode.light)
-                        Text("Dark").tag(ThemeMode.dark)
+                        Label("System", systemImage: "circle.lefthalf.filled").tag(ThemeMode.system)
+                        Label("Light", systemImage: "sun.max").tag(ThemeMode.light)
+                        Label("Dark", systemImage: "moon").tag(ThemeMode.dark)
                     }
                     .pickerStyle(.inline)
                     
@@ -517,6 +517,8 @@ struct BitDreamApp: App {
                         Label("Toggle Appearance", systemImage: "circle.lefthalf.filled")
                     }
                     .keyboardShortcut("j", modifiers: .command)
+                } label: {
+                    Label("Appearance", systemImage: "circle.lefthalf.filled")
                 }
                 Divider()
             }


### PR DESCRIPTION
This pull request updates the command menus and window management in `BitDreamApp.swift` to improve the user interface and follow platform conventions. The most important changes include refactoring command buttons to use labels with system icons for better accessibility and visual clarity, and updating the implementation of utility and auxiliary windows to match Apple's recommended patterns.

**UI Improvements to Command Menus:**

* All command buttons (`SearchCommands`, `FileCommands`, `TorrentCommands`, `AppCommands`, and appearance toggle) now use `Label` with system icons instead of plain text, improving accessibility and visual clarity. [[1]](diffhunk://#diff-ab4edbde2a77d7dcbf84d77c2a74de2e82682c04cae78fd04a2dcbb6606d7ac4L24-R27) [[2]](diffhunk://#diff-ab4edbde2a77d7dcbf84d77c2a74de2e82682c04cae78fd04a2dcbb6606d7ac4L38-R71) [[3]](diffhunk://#diff-ab4edbde2a77d7dcbf84d77c2a74de2e82682c04cae78fd04a2dcbb6606d7ac4L79-R154) [[4]](diffhunk://#diff-ab4edbde2a77d7dcbf84d77c2a74de2e82682c04cae78fd04a2dcbb6606d7ac4L305-R336) [[5]](diffhunk://#diff-ab4edbde2a77d7dcbf84d77c2a74de2e82682c04cae78fd04a2dcbb6606d7ac4L476-R506) [[6]](diffhunk://#diff-ab4edbde2a77d7dcbf84d77c2a74de2e82682c04cae78fd04a2dcbb6606d7ac4R516-R526)
* All toggles in `ViewCommands` now use `Label` with system icons for consistency with the rest of the UI.

**Window Management and Platform Convention Updates:**

* The Statistics window now uses `Window` (not `WindowGroup`) so it appears in the Window menu and is user-manageable, following Apple's conventions for utility windows.
* The About window now uses `WindowGroup` (not `Window`), preventing it from appearing in the Window menu and making it informational-only, as recommended by Apple. The window title is now set via `.navigationTitle`.