### PR TITLE
Add queue position controls

### DIFF
--- a/BitDream/BitDreamApp.swift
+++ b/BitDream/BitDreamApp.swift
@@ -120,6 +120,37 @@ struct TorrentCommands: Commands {
             
             Divider()
             
+            // Queue movement actions
+            Button(action: {
+                moveSelectedTorrentsToFront()
+            }) {
+                Label("Move to Front of Queue", systemImage: "arrow.up.to.line")
+            }
+            .disabled(store.selectedTorrents.isEmpty)
+            
+            Button(action: {
+                moveSelectedTorrentsUp()
+            }) {
+                Label("Move Up in Queue", systemImage: "arrow.up")
+            }
+            .disabled(store.selectedTorrents.isEmpty)
+            
+            Button(action: {
+                moveSelectedTorrentsDown()
+            }) {
+                Label("Move Down in Queue", systemImage: "arrow.down")
+            }
+            .disabled(store.selectedTorrents.isEmpty)
+            
+            Button(action: {
+                moveSelectedTorrentsToBack()
+            }) {
+                Label("Move to Back of Queue", systemImage: "arrow.down.to.line")
+            }
+            .disabled(store.selectedTorrents.isEmpty)
+            
+            Divider()
+            
             // All torrents actions
             Button(action: {
                 pauseAllTorrents()
@@ -298,6 +329,84 @@ struct TorrentCommands: Commands {
                     }
                 )
             }
+        }
+    }
+    
+    // MARK: - Queue Movement Helper Functions
+    
+    private func moveSelectedTorrentsToFront() {
+        let selectedIds = Array(store.selectedTorrents.map { $0.id })
+        guard !selectedIds.isEmpty else { return }
+        
+        let info = makeConfig(store: store)
+        queueMoveTop(ids: selectedIds, info: info) { response in
+            handleTransmissionResponse(response,
+                onSuccess: {},
+                onError: { error in
+                    DispatchQueue.main.async {
+                        store.globalAlertTitle = "Queue Error"
+                        store.globalAlertMessage = error
+                        store.showGlobalAlert = true
+                    }
+                }
+            )
+        }
+    }
+    
+    private func moveSelectedTorrentsUp() {
+        let selectedIds = Array(store.selectedTorrents.map { $0.id })
+        guard !selectedIds.isEmpty else { return }
+        
+        let info = makeConfig(store: store)
+        queueMoveUp(ids: selectedIds, info: info) { response in
+            handleTransmissionResponse(response,
+                onSuccess: {},
+                onError: { error in
+                    DispatchQueue.main.async {
+                        store.globalAlertTitle = "Queue Error"
+                        store.globalAlertMessage = error
+                        store.showGlobalAlert = true
+                    }
+                }
+            )
+        }
+    }
+    
+    private func moveSelectedTorrentsDown() {
+        let selectedIds = Array(store.selectedTorrents.map { $0.id })
+        guard !selectedIds.isEmpty else { return }
+        
+        let info = makeConfig(store: store)
+        queueMoveDown(ids: selectedIds, info: info) { response in
+            handleTransmissionResponse(response,
+                onSuccess: {},
+                onError: { error in
+                    DispatchQueue.main.async {
+                        store.globalAlertTitle = "Queue Error"
+                        store.globalAlertMessage = error
+                        store.showGlobalAlert = true
+                    }
+                }
+            )
+        }
+    }
+    
+    private func moveSelectedTorrentsToBack() {
+        let selectedIds = Array(store.selectedTorrents.map { $0.id })
+        guard !selectedIds.isEmpty else { return }
+        
+        let info = makeConfig(store: store)
+        queueMoveBottom(ids: selectedIds, info: info) { response in
+            handleTransmissionResponse(response,
+                onSuccess: {},
+                onError: { error in
+                    DispatchQueue.main.async {
+                        store.globalAlertTitle = "Queue Error"
+                        store.globalAlertMessage = error
+                        store.showGlobalAlert = true
+                    }
+                }
+            )
         }
     }
 }

--- a/BitDream/Transmission/TransmissionFunctions.swift
+++ b/BitDream/Transmission/TransmissionFunctions.swift
@@ -192,7 +192,7 @@ public func getTorrents(config: TransmissionConfig, auth: TransmissionAuth, onRe
         "eta", "haveUnchecked", "haveValid", "id", "isFinished", "isStalled", 
         "labels", "leftUntilDone", "magnetLink", "metadataPercentComplete", 
         "name", "peersConnected", "peersGettingFromUs", "peersSendingToUs", 
-        "percentDone", "primary-mime-type", "rateDownload", "rateUpload", "sizeWhenDone", "totalSize", "status", "uploadRatio", "uploadedEver", "downloadedEver"
+        "percentDone", "primary-mime-type", "queuePosition", "rateDownload", "rateUpload", "sizeWhenDone", "totalSize", "status", "uploadRatio", "uploadedEver", "downloadedEver"
     ]
     
     performTransmissionDataRequest(
@@ -519,4 +519,82 @@ public func setFilePriority(
     }
     
     updateTorrent(args: args, info: info, onComplete: completion)
+}
+
+// MARK: - Queue Management Functions
+
+/// Move torrents to the top of the queue
+/// - Parameters:
+///   - ids: Array of torrent IDs to move
+///   - info: Tuple containing server config and auth info
+///   - completion: Called when the server's response is received
+public func queueMoveTop(
+    ids: [Int],
+    info: (config: TransmissionConfig, auth: TransmissionAuth),
+    completion: @escaping (TransmissionResponse) -> Void
+) {
+    performTransmissionStatusRequest(
+        method: "queue-move-top",
+        args: ["ids": ids] as [String: [Int]],
+        config: info.config,
+        auth: info.auth,
+        completion: completion
+    )
+}
+
+/// Move torrents up one position in the queue
+/// - Parameters:
+///   - ids: Array of torrent IDs to move
+///   - info: Tuple containing server config and auth info
+///   - completion: Called when the server's response is received
+public func queueMoveUp(
+    ids: [Int],
+    info: (config: TransmissionConfig, auth: TransmissionAuth),
+    completion: @escaping (TransmissionResponse) -> Void
+) {
+    performTransmissionStatusRequest(
+        method: "queue-move-up",
+        args: ["ids": ids] as [String: [Int]],
+        config: info.config,
+        auth: info.auth,
+        completion: completion
+    )
+}
+
+/// Move torrents down one position in the queue
+/// - Parameters:
+///   - ids: Array of torrent IDs to move
+///   - info: Tuple containing server config and auth info
+///   - completion: Called when the server's response is received
+public func queueMoveDown(
+    ids: [Int],
+    info: (config: TransmissionConfig, auth: TransmissionAuth),
+    completion: @escaping (TransmissionResponse) -> Void
+) {
+    performTransmissionStatusRequest(
+        method: "queue-move-down",
+        args: ["ids": ids] as [String: [Int]],
+        config: info.config,
+        auth: info.auth,
+        completion: completion
+    )
+}
+
+/// Move torrents to the bottom of the queue
+/// - Parameters:
+///   - ids: Array of torrent IDs to move
+///   - info: Tuple containing server config and auth info
+///   - completion: Called when the server's response is received
+public func queueMoveBottom(
+    ids: [Int],
+    info: (config: TransmissionConfig, auth: TransmissionAuth),
+    completion: @escaping (TransmissionResponse) -> Void
+) {
+    performTransmissionStatusRequest(
+        method: "queue-move-bottom",
+        args: ["ids": ids] as [String: [Int]],
+        config: info.config,
+        auth: info.auth,
+        completion: completion
+    )
 }

--- a/BitDream/Transmission/TransmissionModels.swift
+++ b/BitDream/Transmission/TransmissionModels.swift
@@ -104,6 +104,7 @@ public struct Torrent: Codable, Hashable, Identifiable {
     let peersSendingToUs: Int
     let percentDone: Double
     let primaryMimeType: String?
+    let queuePosition: Int
     let rateDownload: Int64
     let rateUpload: Int64
     let sizeWhenDone: Int64
@@ -168,6 +169,7 @@ public struct Torrent: Codable, Hashable, Identifiable {
         case peersSendingToUs
         case percentDone
         case primaryMimeType = "primary-mime-type"
+        case queuePosition
         case rateDownload
         case rateUpload
         case sizeWhenDone

--- a/BitDream/Views/iOS/iOSTorrentListRow.swift
+++ b/BitDream/Views/iOS/iOSTorrentListRow.swift
@@ -60,6 +60,8 @@ struct iOSTorrentListRow: View {
 
         Divider()
         
+        // MARK: - Priority & Queue Section
+        
         // Priority Menu
         Menu {
             Button(action: {
@@ -104,6 +106,70 @@ struct iOSTorrentListRow: View {
         } label: {
             Label("Update Priority", systemImage: "flag.badge.ellipsis")
         }
+
+        // Queue Position Menu
+        Menu {
+            Button(action: {
+                let info = makeConfig(store: store)
+                queueMoveTop(ids: [torrent.id], info: info) { response in
+                    handleTransmissionResponse(response,
+                        onSuccess: {},
+                        onError: { error in
+                            errorMessage = error
+                            showingError = true
+                        }
+                    )
+                }
+            }) {
+                Label("Move to Front", systemImage: "arrow.up.to.line")
+            }
+            Button(action: {
+                let info = makeConfig(store: store)
+                queueMoveUp(ids: [torrent.id], info: info) { response in
+                    handleTransmissionResponse(response,
+                        onSuccess: {},
+                        onError: { error in
+                            errorMessage = error
+                            showingError = true
+                        }
+                    )
+                }
+            }) {
+                Label("Move Up", systemImage: "arrow.up")
+            }
+            Button(action: {
+                let info = makeConfig(store: store)
+                queueMoveDown(ids: [torrent.id], info: info) { response in
+                    handleTransmissionResponse(response,
+                        onSuccess: {},
+                        onError: { error in
+                            errorMessage = error
+                            showingError = true
+                        }
+                    )
+                }
+            }) {
+                Label("Move Down", systemImage: "arrow.down")
+            }
+            Button(action: {
+                let info = makeConfig(store: store)
+                queueMoveBottom(ids: [torrent.id], info: info) { response in
+                    handleTransmissionResponse(response,
+                        onSuccess: {},
+                        onError: { error in
+                            errorMessage = error
+                            showingError = true
+                        }
+                    )
+                }
+            }) {
+                Label("Move to Back", systemImage: "arrow.down.to.line")
+            }
+        } label: {
+            Label("Move in Queue", systemImage: "line.3.horizontal")
+        }
+
+        Divider()
 
         // Rename
         Button(action: {

--- a/BitDream/Views/macOS/macOSTorrentList.swift
+++ b/BitDream/Views/macOS/macOSTorrentList.swift
@@ -156,6 +156,8 @@ func createTorrentContextMenu(
 
     Divider()
     
+    // MARK: - Priority & Queue Section
+    
     // Priority Menu
     Menu {
         Button(action: {
@@ -216,6 +218,90 @@ func createTorrentContextMenu(
             Text("Update Priority")
         }
     }
+
+    // Queue Position Menu
+    Menu {
+        Button(action: {
+            let info = makeConfig(store: store)
+            queueMoveTop(ids: Array(torrents.map { $0.id }), info: info) { response in
+                handleTransmissionResponse(response,
+                    onSuccess: {},
+                    onError: { error in
+                        errorMessage.wrappedValue = error
+                        showingError.wrappedValue = true
+                    }
+                )
+            }
+        }) {
+            HStack {
+                Image(systemName: "arrow.up.to.line")
+                    .foregroundStyle(.secondary)
+                Text("Move to Front")
+            }
+        }
+        Button(action: {
+            let info = makeConfig(store: store)
+            queueMoveUp(ids: Array(torrents.map { $0.id }), info: info) { response in
+                handleTransmissionResponse(response,
+                    onSuccess: {},
+                    onError: { error in
+                        errorMessage.wrappedValue = error
+                        showingError.wrappedValue = true
+                    }
+                )
+            }
+        }) {
+            HStack {
+                Image(systemName: "arrow.up")
+                    .foregroundStyle(.secondary)
+                Text("Move Up")
+            }
+        }
+        Button(action: {
+            let info = makeConfig(store: store)
+            queueMoveDown(ids: Array(torrents.map { $0.id }), info: info) { response in
+                handleTransmissionResponse(response,
+                    onSuccess: {},
+                    onError: { error in
+                        errorMessage.wrappedValue = error
+                        showingError.wrappedValue = true
+                    }
+                )
+            }
+        }) {
+            HStack {
+                Image(systemName: "arrow.down")
+                    .foregroundStyle(.secondary)
+                Text("Move Down")
+            }
+        }
+        Button(action: {
+            let info = makeConfig(store: store)
+            queueMoveBottom(ids: Array(torrents.map { $0.id }), info: info) { response in
+                handleTransmissionResponse(response,
+                    onSuccess: {},
+                    onError: { error in
+                        errorMessage.wrappedValue = error
+                        showingError.wrappedValue = true
+                    }
+                )
+            }
+        }) {
+            HStack {
+                Image(systemName: "arrow.down.to.line")
+                    .foregroundStyle(.secondary)
+                Text("Move to Back")
+            }
+        }
+    } label: {
+        HStack {
+            Image(systemName: "line.3.horizontal")
+                .foregroundStyle(.secondary)
+            Text("Move in Queue")
+        }
+    }
+
+    Divider()
 
     // Rename Button (moved into edit section)
     Button(action: {


### PR DESCRIPTION
This pull request adds queue management functionality to the app, allowing users to change the position of torrents in the queue from both the iOS and macOS interfaces. It introduces new UI actions and backend support for moving torrents to the front, up, down, or to the back of the queue, and updates the data model to track queue position.

Queue management features:

* Added queue movement actions (move to front, up, down, back) to the torrent command menu in `BitDreamApp.swift`, enabling users to reposition selected torrents in the queue.
* Implemented helper functions (`moveSelectedTorrentsToFront`, `moveSelectedTorrentsUp`, `moveSelectedTorrentsDown`, `moveSelectedTorrentsToBack`) to handle queue movement actions and display error alerts if needed.
* Added queue management API functions (`queueMoveTop`, `queueMoveUp`, `queueMoveDown`, `queueMoveBottom`) in `TransmissionFunctions.swift` to communicate with the Transmission backend for queue operations.

UI enhancements:

* Added "Move in Queue" menu to both iOS (`iOSTorrentListRow.swift`) and macOS (`macOSTorrentList.swift`) torrent context menus, allowing users to change the queue position of torrents directly from the UI. [[1]](diffhunk://#diff-c8c46a1f68a61bf0fceefdc61c59973dff0db56c5db344deb3daa00a5fd0c04dR110-R173) [[2]](diffhunk://#diff-384ab9a7ae0f97c6a47f40344f457411ff2ab50eab8dea9099377f8229caa7f4R222-R305)

Data model updates:

* Updated the `Torrent` model to include the `queuePosition` property and ensured it is decoded from API responses, so the UI can display and manage torrent positions. [[1]](diffhunk://#diff-261999a529d44cb7722f18631f0ac3bb3e151d7340ff8ebfd43431e64a22ec8dR107) [[2]](diffhunk://#diff-261999a529d44cb7722f18631f0ac3bb3e151d7340ff8ebfd43431e64a22ec8dR172)

Additionally, the API request for torrents now fetches the `queuePosition` field to support these new features.