### PR TITLE
Fix startup connection behavior by persisting last-used server

### DIFF
--- a/BitDream/Store.swift
+++ b/BitDream/Store.swift
@@ -157,6 +157,7 @@ class Store: NSObject, ObservableObject {
         let auth = TransmissionAuth(username: host.username!, password: readPassword(name: host.name!))
         self.server = Server(config: config, auth: auth)
         self.host = host
+        UserDefaults.standard.set(host.objectID.uriRepresentation().absoluteString, forKey: UserDefaultsKeys.selectedHost)
         resetReconnectState()
 
         // Clear all local state so UI/actions can't use stale data from the previous host

--- a/BitDream/Views/Shared/ContentView.swift
+++ b/BitDream/Views/Shared/ContentView.swift
@@ -108,11 +108,13 @@ func setupHost(hosts: FetchedResults<Host>, store: Store) {
     switch behavior {
     case .lastUsed:
         if let savedHostURI = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedHost),
-           !savedHostURI.isEmpty,
-           let savedHostURL = URL(string: savedHostURI),
-           let savedHost = hosts.first(where: { $0.objectID.uriRepresentation() == savedHostURL }) {
-            store.setHost(host: savedHost)
-            return
+           !savedHostURI.isEmpty {
+            if let savedHostURL = URL(string: savedHostURI),
+               let savedHost = hosts.first(where: { $0.objectID.uriRepresentation() == savedHostURL }) {
+                store.setHost(host: savedHost)
+                return
+            }
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedHost)
         }
         if connectToDefaultOrFirst() { return }
         store.setup = true


### PR DESCRIPTION
- Save the selected host whenever Store.setHost runs so “Last used server” has real data.
- Clear stale saved-host IDs during startup if the host no longer exists.
- Maintain fallback to default/first host when needed.