### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Write CI build settings override
+        env:
+          SPARKLE_APPCAST_URL: ${{ vars.SPARKLE_APPCAST_URL }}
+          SPARKLE_PUBLIC_KEY: ${{ vars.SPARKLE_PUBLIC_KEY }}
+        run: |
+          if [[ -z "${SPARKLE_APPCAST_URL:-}" ]]; then
+            echo "Missing required repository variable: SPARKLE_APPCAST_URL"
+            exit 1
+          fi
+
+          if [[ -z "${SPARKLE_PUBLIC_KEY:-}" ]]; then
+            echo "Missing required repository variable: SPARKLE_PUBLIC_KEY"
+            exit 1
+          fi
+
+          cat > Config/BuildSettings.local.xcconfig <<EOF
+          SPARKLE_APPCAST_URL = $SPARKLE_APPCAST_URL
+          SPARKLE_PUBLIC_KEY = $SPARKLE_PUBLIC_KEY
+          EOF
+
       - name: Build app (macOS)
         run: |
           xcodebuild build \
@@ -40,6 +60,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Write CI build settings override
+        env:
+          SPARKLE_APPCAST_URL: ${{ vars.SPARKLE_APPCAST_URL }}
+          SPARKLE_PUBLIC_KEY: ${{ vars.SPARKLE_PUBLIC_KEY }}
+        run: |
+          if [[ -z "${SPARKLE_APPCAST_URL:-}" ]]; then
+            echo "Missing required repository variable: SPARKLE_APPCAST_URL"
+            exit 1
+          fi
+
+          if [[ -z "${SPARKLE_PUBLIC_KEY:-}" ]]; then
+            echo "Missing required repository variable: SPARKLE_PUBLIC_KEY"
+            exit 1
+          fi
+
+          cat > Config/BuildSettings.local.xcconfig <<EOF
+          SPARKLE_APPCAST_URL = $SPARKLE_APPCAST_URL
+          SPARKLE_PUBLIC_KEY = $SPARKLE_PUBLIC_KEY
+          EOF
 
       - name: Build app (iOS)
         run: |


### PR DESCRIPTION
Introduce a new GitHub Actions workflow (ci.yml) that runs on pull requests and merge_group events. Adds two jobs (macOS and iOS) running on macos-26 which checkout the repo and run xcodebuild for the BitDream Xcode project/scheme in Debug configuration, targeting generic macOS and iOS platforms. Derived data is placed in the runner temp directory and code signing is disabled to allow CI builds. Concurrency and minimal contents permissions are configured.