### PR TITLE
Refactor the Transmission migration surface for caller adoption

### DIFF
--- a/BitDream.xcodeproj/project.pbxproj
+++ b/BitDream.xcodeproj/project.pbxproj
@@ -104,6 +104,10 @@
 		5A1000014100000000A1B2C3 /* TransmissionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1000064100000000A1B2C3 /* TransmissionModels.swift */; };
 		5A1000214100000000A1B2C3 /* TransmissionTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1000224100000000A1B2C3 /* TransmissionTransport.swift */; };
 		5A1000234100000000A1B2C3 /* TransmissionConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1000244100000000A1B2C3 /* TransmissionConnection.swift */; };
+		6A1000014200000000A1B2C3 /* TransmissionConnectionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1000024200000000A1B2C3 /* TransmissionConnectionFactory.swift */; };
+		6A1000034200000000A1B2C3 /* TransmissionTorrents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1000044200000000A1B2C3 /* TransmissionTorrents.swift */; };
+		6A1000054200000000A1B2C3 /* TransmissionSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1000064200000000A1B2C3 /* TransmissionSession.swift */; };
+		6A1000074200000000A1B2C3 /* TransmissionErrorPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1000084200000000A1B2C3 /* TransmissionErrorPresentation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -235,6 +239,10 @@
 		5A1000074100000000A1B2C3 /* BitDreamTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BitDreamTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A1000224100000000A1B2C3 /* TransmissionTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionTransport.swift; sourceTree = "<group>"; };
 		5A1000244100000000A1B2C3 /* TransmissionConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionConnection.swift; sourceTree = "<group>"; };
+		6A1000024200000000A1B2C3 /* TransmissionConnectionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionConnectionFactory.swift; sourceTree = "<group>"; };
+		6A1000044200000000A1B2C3 /* TransmissionTorrents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionTorrents.swift; sourceTree = "<group>"; };
+		6A1000064200000000A1B2C3 /* TransmissionSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionSession.swift; sourceTree = "<group>"; };
+		6A1000084200000000A1B2C3 /* TransmissionErrorPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionErrorPresentation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -373,6 +381,10 @@
 				5A1000064100000000A1B2C3 /* TransmissionModels.swift */,
 				5A1000224100000000A1B2C3 /* TransmissionTransport.swift */,
 				5A1000244100000000A1B2C3 /* TransmissionConnection.swift */,
+				6A1000024200000000A1B2C3 /* TransmissionConnectionFactory.swift */,
+				6A1000044200000000A1B2C3 /* TransmissionTorrents.swift */,
+				6A1000064200000000A1B2C3 /* TransmissionSession.swift */,
+				6A1000084200000000A1B2C3 /* TransmissionErrorPresentation.swift */,
 				4D6A00203F00000000A1B2C3 /* TransmissionSessionModels.swift */,
 				4B1DADFD295E6F390037E9FB /* TransmissionTorrentModels.swift */,
 			);
@@ -727,6 +739,10 @@
 				5A1000014100000000A1B2C3 /* TransmissionModels.swift in Sources */,
 				5A1000214100000000A1B2C3 /* TransmissionTransport.swift in Sources */,
 				5A1000234100000000A1B2C3 /* TransmissionConnection.swift in Sources */,
+				6A1000014200000000A1B2C3 /* TransmissionConnectionFactory.swift in Sources */,
+				6A1000034200000000A1B2C3 /* TransmissionTorrents.swift in Sources */,
+				6A1000054200000000A1B2C3 /* TransmissionSession.swift in Sources */,
+				6A1000074200000000A1B2C3 /* TransmissionErrorPresentation.swift in Sources */,
 				4BDE147F2F0B015C00FF6A46 /* AppIconManager.swift in Sources */,
 				4BD938EB2D82AF6F006CE97C /* ThemeManager.swift in Sources */,
 				4B1DADFE295E6F390037E9FB /* TransmissionTorrentModels.swift in Sources */,

--- a/BitDream/Models/Host.swift
+++ b/BitDream/Models/Host.swift
@@ -49,3 +49,15 @@ final class Host {
         return generated
     }
 }
+
+extension TransmissionConnectionDescriptor {
+    init(host: Host) {
+        self.init(
+            scheme: host.isSSL ? "https" : "http",
+            host: host.server ?? "",
+            port: Int(host.port),
+            username: host.username ?? "",
+            credentialSource: .keychainCredential(KeychainService.credentialKeyIfPresent(for: host) ?? "")
+        )
+    }
+}

--- a/BitDream/Transmission/TransmissionConnectionFactory.swift
+++ b/BitDream/Transmission/TransmissionConnectionFactory.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+internal struct TransmissionCredentialResolver: Sendable {
+    private let resolvePassword: @Sendable (TransmissionCredentialSource) -> String
+
+    init(resolvePassword: @escaping @Sendable (TransmissionCredentialSource) -> String) {
+        self.resolvePassword = resolvePassword
+    }
+
+    func password(for source: TransmissionCredentialSource) -> String {
+        resolvePassword(source)
+    }
+
+    static let live = Self { source in
+        switch source {
+        case .resolvedPassword(let password):
+            return password
+        case .keychainCredential(let credentialKey):
+            let trimmedKey = credentialKey.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedKey.isEmpty else {
+                return ""
+            }
+
+            return KeychainService.readPassword(credentialKey: trimmedKey)
+        }
+    }
+}
+
+internal actor TransmissionConnectionFactory {
+    private struct Key: Hashable, Sendable {
+        let endpoint: TransmissionEndpoint
+        let auth: TransmissionAuth
+    }
+
+    private let transport: TransmissionTransport
+    private let credentialResolver: TransmissionCredentialResolver
+    private var connections: [Key: TransmissionConnection] = [:]
+
+    init(
+        transport: TransmissionTransport = TransmissionTransport(),
+        credentialResolver: TransmissionCredentialResolver = .live
+    ) {
+        self.transport = transport
+        self.credentialResolver = credentialResolver
+    }
+
+    func connection(for descriptor: TransmissionConnectionDescriptor) throws -> TransmissionConnection {
+        let endpoint = try TransmissionEndpoint(
+            scheme: descriptor.scheme,
+            host: descriptor.host,
+            port: descriptor.port
+        )
+        let auth = TransmissionAuth(
+            username: descriptor.username,
+            password: credentialResolver.password(for: descriptor.credentialSource)
+        )
+        let key = Key(endpoint: endpoint, auth: auth)
+
+        if let existing = connections[key] {
+            return existing
+        }
+
+        let connection = TransmissionConnection(endpoint: endpoint, auth: auth, transport: transport)
+        connections[key] = connection
+        return connection
+    }
+}

--- a/BitDream/Transmission/TransmissionErrorPresentation.swift
+++ b/BitDream/Transmission/TransmissionErrorPresentation.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+struct TransmissionErrorPresentation: Equatable, Sendable {
+    let title: String?
+    let message: String
+}
+
+enum TransmissionErrorPresenter {
+    static func presentation(for error: TransmissionError) -> TransmissionErrorPresentation {
+        switch error {
+        case .invalidEndpointConfiguration:
+            return connectionError(message: "Connection error. Please check your server settings.")
+        case .unauthorized:
+            return authenticationFailed(message: "Authentication failed. Please check your server credentials.")
+        case .transport(let underlyingDescription):
+            return connectionError(message: underlyingDescription)
+        case .timeout:
+            return connectionTimedOut(message: "The request timed out.")
+        case .cancelled:
+            return requestCancelled(message: "The request was cancelled.")
+        case .httpStatus(let code, let body):
+            return serverError(message: httpStatusMessage(code: code, body: body))
+        case .rpcFailure(let result):
+            return operationFailed(message: result)
+        case .invalidResponse:
+            return serverError(message: "The server returned an invalid response.")
+        case .decoding:
+            return serverError(message: "Failed to decode the server response.")
+        }
+    }
+
+    private static func connectionError(message: String) -> TransmissionErrorPresentation {
+        TransmissionErrorPresentation(title: "Connection Error", message: message)
+    }
+
+    private static func authenticationFailed(message: String) -> TransmissionErrorPresentation {
+        TransmissionErrorPresentation(title: "Authentication Failed", message: message)
+    }
+
+    private static func connectionTimedOut(message: String) -> TransmissionErrorPresentation {
+        TransmissionErrorPresentation(title: "Connection Timed Out", message: message)
+    }
+
+    private static func requestCancelled(message: String) -> TransmissionErrorPresentation {
+        TransmissionErrorPresentation(title: "Request Cancelled", message: message)
+    }
+
+    private static func serverError(message: String) -> TransmissionErrorPresentation {
+        TransmissionErrorPresentation(title: "Server Error", message: message)
+    }
+
+    private static func operationFailed(message: String) -> TransmissionErrorPresentation {
+        TransmissionErrorPresentation(title: "Operation Failed", message: message)
+    }
+
+    private static func httpStatusMessage(code: Int, body: String?) -> String {
+        if let body, !body.isEmpty {
+            return body
+        }
+
+        return "Server returned HTTP \(code)."
+    }
+}
+
+struct TransmissionLegacyCompatibilityError: LocalizedError, Sendable {
+    let transmissionError: TransmissionError
+
+    var errorDescription: String? {
+        TransmissionErrorPresenter.presentation(for: transmissionError).message
+    }
+}
+
+enum TransmissionLegacyCompatibility {
+    static func response(from error: Error) -> TransmissionResponse {
+        response(from: transmissionError(from: error))
+    }
+
+    static func response(from error: TransmissionError) -> TransmissionResponse {
+        switch error {
+        case .unauthorized:
+            return .unauthorized
+        case .invalidEndpointConfiguration, .transport, .timeout:
+            return .configError
+        case .rpcFailure, .httpStatus, .invalidResponse, .decoding, .cancelled:
+            return .failed
+        }
+    }
+
+    static func localizedError(from error: Error) -> Error {
+        TransmissionLegacyCompatibilityError(transmissionError: transmissionError(from: error))
+    }
+
+    static func presentation(for response: TransmissionResponse) -> TransmissionErrorPresentation? {
+        switch response {
+        case .success:
+            return nil
+        case .unauthorized:
+            return TransmissionErrorPresenter.presentation(for: .unauthorized)
+        case .configError:
+            return TransmissionErrorPresenter.presentation(for: .invalidEndpointConfiguration)
+        case .failed:
+            return TransmissionErrorPresentation(
+                title: "Operation Failed",
+                message: "Operation failed. Please try again."
+            )
+        }
+    }
+
+    static func transmissionError(from error: Error) -> TransmissionError {
+        if let compatibilityError = error as? TransmissionLegacyCompatibilityError {
+            return compatibilityError.transmissionError
+        }
+
+        if let transmissionError = error as? TransmissionError {
+            return transmissionError
+        }
+
+        if let transportFailure = error as? TransmissionTransportFailure {
+            return transportFailure.transmissionError
+        }
+
+        return .transport(underlyingDescription: error.localizedDescription)
+    }
+}

--- a/BitDream/Transmission/TransmissionFunctions.swift
+++ b/BitDream/Transmission/TransmissionFunctions.swift
@@ -1,65 +1,20 @@
 import Foundation
 
-internal struct TransmissionLegacyCompatibilityError: LocalizedError, Sendable {
-    let transmissionError: TransmissionError
-
-    var errorDescription: String? {
-        switch transmissionError {
-        case .invalidEndpointConfiguration:
-            return "Connection error. Please check your server settings."
-        case .unauthorized:
-            return "Authentication failed. Please check your server credentials."
-        case .transport(let underlyingDescription):
-            return underlyingDescription
-        case .timeout:
-            return "The request timed out."
-        case .cancelled:
-            return "The request was cancelled."
-        case .httpStatus(let code, let body):
-            if let body, !body.isEmpty {
-                return body
-            }
-            return "Server returned HTTP \(code)."
-        case .rpcFailure(let result):
-            return result
-        case .invalidResponse:
-            return "The server returned an invalid response."
-        case .decoding:
-            return "Failed to decode the server response."
-        }
-    }
-}
-
-private actor TransmissionLegacyConnectionCache {
-    private struct Key: Hashable, Sendable {
-        let endpoint: TransmissionEndpoint
-        let auth: TransmissionAuth
-    }
-
-    private let transport: TransmissionTransport
-    private var connections: [Key: TransmissionConnection] = [:]
-
-    init(transport: TransmissionTransport) {
-        self.transport = transport
-    }
-
-    func connection(endpoint: TransmissionEndpoint, auth: TransmissionAuth) -> TransmissionConnection {
-        let key = Key(endpoint: endpoint, auth: auth)
-        if let existing = connections[key] {
-            return existing
-        }
-
-        let connection = TransmissionConnection(endpoint: endpoint, auth: auth, transport: transport)
-        connections[key] = connection
-        return connection
-    }
-}
-
 internal struct TransmissionLegacyAdapter: Sendable {
-    private let connectionCache: TransmissionLegacyConnectionCache
+    private let factory: TransmissionConnectionFactory
 
-    init(transport: TransmissionTransport = TransmissionTransport()) {
-        self.connectionCache = TransmissionLegacyConnectionCache(transport: transport)
+    init(factory: TransmissionConnectionFactory = TransmissionConnectionFactory()) {
+        self.factory = factory
+    }
+
+    init(
+        transport: TransmissionTransport = TransmissionTransport(),
+        credentialResolver: TransmissionCredentialResolver = .live
+    ) {
+        self.factory = TransmissionConnectionFactory(
+            transport: transport,
+            credentialResolver: credentialResolver
+        )
     }
 
     func performDataRequest<Args: Codable & Sendable, ResponseData: Codable & Sendable>(
@@ -78,7 +33,7 @@ internal struct TransmissionLegacyAdapter: Sendable {
             )
             return .success(responseData)
         } catch {
-            return .failure(Self.compatibilityError(from: error))
+            return .failure(TransmissionLegacyCompatibility.localizedError(from: error))
         }
     }
 
@@ -96,7 +51,7 @@ internal struct TransmissionLegacyAdapter: Sendable {
             )
             return .success
         } catch {
-            return Self.compatibilityResponse(from: error)
+            return TransmissionLegacyCompatibility.response(from: error)
         }
     }
 
@@ -114,47 +69,94 @@ internal struct TransmissionLegacyAdapter: Sendable {
                 return (.success, torrent.id)
             }
         } catch {
-            return (Self.compatibilityResponse(from: error), 0)
+            return (TransmissionLegacyCompatibility.response(from: error), 0)
         }
     }
 
-    static func compatibilityResponse(from error: Error) -> TransmissionResponse {
-        switch compatibilityTransmissionError(from: error) {
-        case .unauthorized:
-            return .unauthorized
-        case .invalidEndpointConfiguration, .transport, .timeout:
-            return .configError
-        case .rpcFailure, .httpStatus, .invalidResponse, .decoding, .cancelled:
-            return .failed
+    func fetchTorrentSummary(
+        config: TransmissionConfig,
+        auth: TransmissionAuth
+    ) async -> Result<[Torrent], Error> {
+        await performQuery(config: config, auth: auth) { connection in
+            try await connection.fetchTorrentSummary()
         }
     }
 
-    static func compatibilityError(from error: Error) -> Error {
-        TransmissionLegacyCompatibilityError(transmissionError: compatibilityTransmissionError(from: error))
+    func fetchWidgetSummary(
+        config: TransmissionConfig,
+        auth: TransmissionAuth
+    ) async -> Result<[Torrent], Error> {
+        await performQuery(config: config, auth: auth) { connection in
+            try await connection.fetchWidgetSummary()
+        }
+    }
+
+    func fetchTorrentFiles(
+        transferID: Int,
+        config: TransmissionConfig,
+        auth: TransmissionAuth
+    ) async -> Result<TorrentFilesResponseData, Error> {
+        await performQuery(config: config, auth: auth) { connection in
+            try await connection.fetchTorrentFiles(id: transferID)
+        }
+    }
+
+    func fetchTorrentPeers(
+        transferID: Int,
+        config: TransmissionConfig,
+        auth: TransmissionAuth
+    ) async -> Result<TorrentPeersResponseData, Error> {
+        await performQuery(config: config, auth: auth) { connection in
+            try await connection.fetchTorrentPeers(id: transferID)
+        }
+    }
+
+    func fetchTorrentPieces(
+        transferID: Int,
+        config: TransmissionConfig,
+        auth: TransmissionAuth
+    ) async -> Result<TorrentPiecesResponseData, Error> {
+        await performQuery(config: config, auth: auth) { connection in
+            try await connection.fetchTorrentPieces(id: transferID)
+        }
+    }
+
+    func fetchSessionStats(
+        config: TransmissionConfig,
+        auth: TransmissionAuth
+    ) async -> Result<SessionStats, Error> {
+        await performQuery(config: config, auth: auth) { connection in
+            try await connection.fetchSessionStats()
+        }
+    }
+
+    func fetchSessionSettings(
+        config: TransmissionConfig,
+        auth: TransmissionAuth
+    ) async -> Result<TransmissionSessionResponseArguments, Error> {
+        await performQuery(config: config, auth: auth) { connection in
+            try await connection.fetchSessionSettings()
+        }
     }
 
     private func connection(
         for config: TransmissionConfig,
         auth: TransmissionAuth
     ) async throws -> TransmissionConnection {
-        let endpoint = try TransmissionEndpoint(config: config)
-        return await connectionCache.connection(endpoint: endpoint, auth: auth)
+        try await factory.connection(for: TransmissionConnectionDescriptor(config: config, auth: auth))
     }
 
-    private static func compatibilityTransmissionError(from error: Error) -> TransmissionError {
-        if let compatibilityError = error as? TransmissionLegacyCompatibilityError {
-            return compatibilityError.transmissionError
+    private func performQuery<Success: Sendable>(
+        config: TransmissionConfig,
+        auth: TransmissionAuth,
+        operation: (TransmissionConnection) async throws -> Success
+    ) async -> Result<Success, Error> {
+        do {
+            let connection = try await connection(for: config, auth: auth)
+            return .success(try await operation(connection))
+        } catch {
+            return .failure(TransmissionLegacyCompatibility.localizedError(from: error))
         }
-
-        if let transmissionError = error as? TransmissionError {
-            return transmissionError
-        }
-
-        if let transportFailure = error as? TransmissionTransportFailure {
-            return transportFailure.transmissionError
-        }
-
-        return .transport(underlyingDescription: error.localizedDescription)
     }
 }
 
@@ -179,25 +181,6 @@ public func performTransmissionDataRequest<Args: Codable & Sendable, ResponseDat
             responseType: ResponseData.self
         )
         await completion(result)
-    }
-}
-
-private func performTransmissionDataRequestInBackground<Args: Codable & Sendable, ResponseData: Codable & Sendable>(
-    method: String,
-    args: Args,
-    config: TransmissionConfig,
-    auth: TransmissionAuth,
-    completion: @Sendable @escaping (Result<ResponseData, Error>) -> Void
-) {
-    Task {
-        let result = await legacyTransmissionAdapter.performDataRequest(
-            method: method,
-            args: args,
-            config: config,
-            auth: auth,
-            responseType: ResponseData.self
-        )
-        completion(result)
     }
 }
 
@@ -243,51 +226,25 @@ private func executeTorrentAction(actionMethod: String, torrentId: Int, config: 
 
 /// Makes a request to the server for a list of the currently running torrents
 public func getTorrents(config: TransmissionConfig, auth: TransmissionAuth, onReceived: @MainActor @escaping ([Torrent]?, String?) -> Void) {
-    let fields: [String] = [
-        "activityDate", "addedDate", "desiredAvailable", "error", "errorString",
-        "eta", "haveUnchecked", "haveValid", "id", "isFinished", "isStalled",
-        "labels", "leftUntilDone", "magnetLink", "metadataPercentComplete",
-        "name", "peersConnected", "peersGettingFromUs", "peersSendingToUs",
-        "percentDone", "primary-mime-type", "downloadDir", "queuePosition",
-        "rateDownload", "rateUpload", "sizeWhenDone", "totalSize", "status",
-        "uploadRatio", "uploadedEver", "downloadedEver"
-    ]
+    Task {
+        let result = await legacyTransmissionAdapter.fetchTorrentSummary(config: config, auth: auth)
 
-    performTransmissionDataRequest(
-        method: "torrent-get",
-        args: ["fields": fields] as StringListArguments,
-        config: config,
-        auth: auth
-    ) { (result: Result<[String: [Torrent]], Error>) in
         switch result {
-        case .success(let response):
-            onReceived(response["torrents"], nil)
+        case .success(let torrents):
+            await onReceived(torrents, nil)
         case .failure(let error):
-            onReceived(nil, error.localizedDescription)
+            await onReceived(nil, error.localizedDescription)
         }
     }
 }
 
 func getTorrentsForWidgetRefresh(config: TransmissionConfig, auth: TransmissionAuth, onReceived: @Sendable @escaping ([Torrent]?, String?) -> Void) {
-    let fields: [String] = [
-        "activityDate", "addedDate", "desiredAvailable", "error", "errorString",
-        "eta", "haveUnchecked", "haveValid", "id", "isFinished", "isStalled",
-        "labels", "leftUntilDone", "magnetLink", "metadataPercentComplete",
-        "name", "peersConnected", "peersGettingFromUs", "peersSendingToUs",
-        "percentDone", "primary-mime-type", "downloadDir", "queuePosition",
-        "rateDownload", "rateUpload", "sizeWhenDone", "totalSize", "status",
-        "uploadRatio", "uploadedEver", "downloadedEver"
-    ]
+    Task {
+        let result = await legacyTransmissionAdapter.fetchWidgetSummary(config: config, auth: auth)
 
-    performTransmissionDataRequestInBackground(
-        method: "torrent-get",
-        args: ["fields": fields] as StringListArguments,
-        config: config,
-        auth: auth
-    ) { (result: Result<[String: [Torrent]], Error>) in
         switch result {
-        case .success(let response):
-            onReceived(response["torrents"], nil)
+        case .success(let torrents):
+            onReceived(torrents, nil)
         case .failure(let error):
             onReceived(nil, error.localizedDescription)
         }
@@ -295,28 +252,22 @@ func getTorrentsForWidgetRefresh(config: TransmissionConfig, auth: TransmissionA
 }
 
 public func getSessionStats(config: TransmissionConfig, auth: TransmissionAuth, onReceived: @MainActor @escaping (SessionStats?, String?) -> Void) {
-    performTransmissionDataRequest(
-        method: "session-stats",
-        args: EmptyArguments(),
-        config: config,
-        auth: auth
-    ) { (result: Result<SessionStats, Error>) in
+    Task {
+        let result = await legacyTransmissionAdapter.fetchSessionStats(config: config, auth: auth)
+
         switch result {
         case .success(let response):
-            onReceived(response, nil)
+            await onReceived(response, nil)
         case .failure(let error):
-            onReceived(nil, error.localizedDescription)
+            await onReceived(nil, error.localizedDescription)
         }
     }
 }
 
 func getSessionStatsForWidgetRefresh(config: TransmissionConfig, auth: TransmissionAuth, onReceived: @Sendable @escaping (SessionStats?, String?) -> Void) {
-    performTransmissionDataRequestInBackground(
-        method: "session-stats",
-        args: EmptyArguments(),
-        config: config,
-        auth: auth
-    ) { (result: Result<SessionStats, Error>) in
+    Task {
+        let result = await legacyTransmissionAdapter.fetchSessionStats(config: config, auth: auth)
+
         switch result {
         case .success(let response):
             onReceived(response, nil)
@@ -363,27 +314,18 @@ public func addTorrent(
 /// - Parameter info: A tuple containing the server config and auth info
 /// - Parameter onReceived: A callback that receives the list of files and their stats
 public func getTorrentFiles(transferId: Int, info: (config: TransmissionConfig, auth: TransmissionAuth), onReceived: @MainActor @escaping ([TorrentFile], [TorrentFileStats]) -> Void) {
-    let args = TorrentFilesRequestArgs(
-        fields: ["files", "fileStats"],
-        ids: [transferId]
-    )
+    Task {
+        let result = await legacyTransmissionAdapter.fetchTorrentFiles(
+            transferID: transferId,
+            config: info.config,
+            auth: info.auth
+        )
 
-    performTransmissionDataRequest(
-        method: "torrent-get",
-        args: args,
-        config: info.config,
-        auth: info.auth
-    ) { (result: Result<TorrentFilesResponseTorrents, Error>) in
         switch result {
         case .success(let response):
-            if let responseFiles = response.torrents.first?.files,
-               let responseStats = response.torrents.first?.fileStats {
-                onReceived(responseFiles, responseStats)
-            } else {
-                onReceived([], [])
-            }
+            await onReceived(response.files, response.fileStats)
         case .failure:
-            onReceived([], [])
+            await onReceived([], [])
         }
     }
 }
@@ -430,70 +372,14 @@ public func getSession(
     onResponse: @MainActor @escaping (TransmissionSessionResponseArguments) -> Void,
     onError: @MainActor @escaping (String) -> Void
 ) {
-    let fields = [
-        // Existing fields
-        "download-dir",
-        "version",
-        // Speed & Bandwidth
-        "speed-limit-down",
-        "speed-limit-down-enabled",
-        "speed-limit-up",
-        "speed-limit-up-enabled",
-        "alt-speed-down",
-        "alt-speed-up",
-        "alt-speed-enabled",
-        "alt-speed-time-begin",
-        "alt-speed-time-end",
-        "alt-speed-time-enabled",
-        "alt-speed-time-day",
-        // File Management
-        "incomplete-dir",
-        "incomplete-dir-enabled",
-        "start-added-torrents",
-        "trash-original-torrent-files",
-        "rename-partial-files",
-        // Queue Management
-        "download-queue-enabled",
-        "download-queue-size",
-        // Seeding
-        "seed-queue-enabled",
-        "seed-queue-size",
-        "seedRatioLimited",
-        "seedRatioLimit",
-        "idle-seeding-limit",
-        "idle-seeding-limit-enabled",
-        "queue-stalled-enabled",
-        "queue-stalled-minutes",
-        // Network Settings
-        "peer-port",
-        "peer-port-random-on-start",
-        "port-forwarding-enabled",
-        "dht-enabled",
-        "pex-enabled",
-        "lpd-enabled",
-        "encryption",
-        "utp-enabled",
-        "peer-limit-global",
-        "peer-limit-per-torrent",
-        // Blocklist
-        "blocklist-enabled",
-        "blocklist-size",
-        "blocklist-url",
-        // Default Trackers
-        "default-trackers"
-    ]
+    Task {
+        let result = await legacyTransmissionAdapter.fetchSessionSettings(config: config, auth: auth)
 
-    performTransmissionDataRequest(
-        method: "session-get",
-        args: ["fields": fields] as StringListArguments,
-        config: config,
-        auth: auth
-    ) { (result: Result<TransmissionSessionResponseArguments, Error>) in
         switch result {
         case .success(let response):
-            onResponse(response)
+            await onResponse(response)
         case .failure(let error):
-            onError(error.localizedDescription)
+            await onError(error.localizedDescription)
         }
     }
 }
@@ -866,26 +752,18 @@ public func getTorrentPeers(
     info: (config: TransmissionConfig, auth: TransmissionAuth),
     onReceived: @MainActor @escaping (_ peers: [Peer], _ peersFrom: PeersFrom?) -> Void
 ) {
-    let args = TorrentFilesRequestArgs(
-        fields: ["peers", "peersFrom"],
-        ids: [transferId]
-    )
+    Task {
+        let result = await legacyTransmissionAdapter.fetchTorrentPeers(
+            transferID: transferId,
+            config: info.config,
+            auth: info.auth
+        )
 
-    performTransmissionDataRequest(
-        method: "torrent-get",
-        args: args,
-        config: info.config,
-        auth: info.auth
-    ) { (result: Result<TorrentPeersResponseTorrents, Error>) in
         switch result {
         case .success(let response):
-            if let peersData = response.torrents.first {
-                onReceived(peersData.peers, peersData.peersFrom)
-            } else {
-                onReceived([], nil)
-            }
+            await onReceived(response.peers, response.peersFrom)
         case .failure:
-            onReceived([], nil)
+            await onReceived([], nil)
         }
     }
 }
@@ -902,26 +780,18 @@ public func getTorrentPieces(
     info: (config: TransmissionConfig, auth: TransmissionAuth),
     onReceived: @MainActor @escaping (_ pieceCount: Int, _ pieceSize: Int64, _ piecesBitfieldBase64: String) -> Void
 ) {
-    let args = TorrentFilesRequestArgs(
-        fields: ["pieceCount", "pieceSize", "pieces"],
-        ids: [transferId]
-    )
+    Task {
+        let result = await legacyTransmissionAdapter.fetchTorrentPieces(
+            transferID: transferId,
+            config: info.config,
+            auth: info.auth
+        )
 
-    performTransmissionDataRequest(
-        method: "torrent-get",
-        args: args,
-        config: info.config,
-        auth: info.auth
-    ) { (result: Result<TorrentPiecesResponseTorrents, Error>) in
         switch result {
         case .success(let response):
-            if let piecesData = response.torrents.first {
-                onReceived(piecesData.pieceCount, piecesData.pieceSize, piecesData.pieces)
-            } else {
-                onReceived(0, 0, "")
-            }
+            await onReceived(response.pieceCount, response.pieceSize, response.pieces)
         case .failure:
-            onReceived(0, 0, "")
+            await onReceived(0, 0, "")
         }
     }
 }

--- a/BitDream/Transmission/TransmissionModels.swift
+++ b/BitDream/Transmission/TransmissionModels.swift
@@ -2,6 +2,47 @@ import Foundation
 
 public typealias TransmissionConfig = URLComponents
 
+internal enum TransmissionCredentialSource: Hashable, Sendable {
+    case resolvedPassword(String)
+    case keychainCredential(String)
+}
+
+internal struct TransmissionConnectionDescriptor: Hashable, Sendable {
+    let scheme: String
+    let host: String
+    let port: Int
+    let username: String
+    let credentialSource: TransmissionCredentialSource
+
+    init(
+        scheme: String,
+        host: String,
+        port: Int,
+        username: String,
+        credentialSource: TransmissionCredentialSource
+    ) {
+        self.scheme = scheme
+        self.host = host
+        self.port = port
+        self.username = username
+        self.credentialSource = credentialSource
+    }
+
+    init(config: TransmissionConfig, auth: TransmissionAuth) {
+        self.init(
+            scheme: config.scheme ?? "",
+            host: config.host ?? "",
+            port: config.port ?? 0,
+            username: auth.username,
+            credentialSource: .resolvedPassword(auth.password)
+        )
+    }
+
+    init(info: (config: TransmissionConfig, auth: TransmissionAuth)) {
+        self.init(config: info.config, auth: info.auth)
+    }
+}
+
 internal struct TransmissionEndpoint: Hashable, Sendable {
     let scheme: String
     let host: String

--- a/BitDream/Transmission/TransmissionSession.swift
+++ b/BitDream/Transmission/TransmissionSession.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+internal struct TransmissionSessionFieldQuerySpec: Sendable {
+    let fields: [String]
+
+    var arguments: StringListArguments {
+        ["fields": fields]
+    }
+}
+
+internal enum TransmissionSessionQuerySpec {
+    static let sessionSettings = TransmissionSessionFieldQuerySpec(fields: [
+        "download-dir",
+        "version",
+        "speed-limit-down",
+        "speed-limit-down-enabled",
+        "speed-limit-up",
+        "speed-limit-up-enabled",
+        "alt-speed-down",
+        "alt-speed-up",
+        "alt-speed-enabled",
+        "alt-speed-time-begin",
+        "alt-speed-time-end",
+        "alt-speed-time-enabled",
+        "alt-speed-time-day",
+        "incomplete-dir",
+        "incomplete-dir-enabled",
+        "start-added-torrents",
+        "trash-original-torrent-files",
+        "rename-partial-files",
+        "download-queue-enabled",
+        "download-queue-size",
+        "seed-queue-enabled",
+        "seed-queue-size",
+        "seedRatioLimited",
+        "seedRatioLimit",
+        "idle-seeding-limit",
+        "idle-seeding-limit-enabled",
+        "queue-stalled-enabled",
+        "queue-stalled-minutes",
+        "peer-port",
+        "peer-port-random-on-start",
+        "port-forwarding-enabled",
+        "dht-enabled",
+        "pex-enabled",
+        "lpd-enabled",
+        "encryption",
+        "utp-enabled",
+        "peer-limit-global",
+        "peer-limit-per-torrent",
+        "blocklist-enabled",
+        "blocklist-size",
+        "blocklist-url",
+        "default-trackers"
+    ])
+}
+
+internal extension TransmissionConnection {
+    func fetchSessionStats() async throws -> SessionStats {
+        try await sendRequiredArguments(
+            method: "session-stats",
+            arguments: EmptyArguments(),
+            responseType: SessionStats.self
+        )
+    }
+
+    func fetchSessionSettings() async throws -> TransmissionSessionResponseArguments {
+        try await sendRequiredArguments(
+            method: "session-get",
+            arguments: TransmissionSessionQuerySpec.sessionSettings.arguments,
+            responseType: TransmissionSessionResponseArguments.self
+        )
+    }
+}

--- a/BitDream/Transmission/TransmissionTorrents.swift
+++ b/BitDream/Transmission/TransmissionTorrents.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+internal struct TransmissionTorrentListQuerySpec: Sendable {
+    let fields: [String]
+
+    var arguments: StringListArguments {
+        ["fields": fields]
+    }
+}
+
+internal struct TransmissionTorrentDetailQuerySpec: Sendable {
+    let fields: [String]
+    let id: Int
+
+    var arguments: TorrentFilesRequestArgs {
+        TorrentFilesRequestArgs(fields: fields, ids: [id])
+    }
+}
+
+internal enum TransmissionTorrentQuerySpec {
+    static let torrentSummary = TransmissionTorrentListQuerySpec(fields: [
+        "activityDate", "addedDate", "desiredAvailable", "error", "errorString",
+        "eta", "haveUnchecked", "haveValid", "id", "isFinished", "isStalled",
+        "labels", "leftUntilDone", "magnetLink", "metadataPercentComplete",
+        "name", "peersConnected", "peersGettingFromUs", "peersSendingToUs",
+        "percentDone", "primary-mime-type", "downloadDir", "queuePosition",
+        "rateDownload", "rateUpload", "sizeWhenDone", "totalSize", "status",
+        "uploadRatio", "uploadedEver", "downloadedEver"
+    ])
+
+    static let widgetSummary = TransmissionTorrentListQuerySpec(fields: [
+        "activityDate", "addedDate", "desiredAvailable", "error", "errorString",
+        "eta", "haveUnchecked", "haveValid", "id", "isFinished", "isStalled",
+        "labels", "leftUntilDone", "magnetLink", "metadataPercentComplete",
+        "name", "peersConnected", "peersGettingFromUs", "peersSendingToUs",
+        "percentDone", "primary-mime-type", "downloadDir", "queuePosition",
+        "rateDownload", "rateUpload", "sizeWhenDone", "totalSize", "status",
+        "uploadRatio", "uploadedEver", "downloadedEver"
+    ])
+
+    static func torrentFiles(id: Int) -> TransmissionTorrentDetailQuerySpec {
+        TransmissionTorrentDetailQuerySpec(fields: ["files", "fileStats"], id: id)
+    }
+
+    static func torrentPeers(id: Int) -> TransmissionTorrentDetailQuerySpec {
+        TransmissionTorrentDetailQuerySpec(fields: ["peers", "peersFrom"], id: id)
+    }
+
+    static func torrentPieces(id: Int) -> TransmissionTorrentDetailQuerySpec {
+        TransmissionTorrentDetailQuerySpec(fields: ["pieceCount", "pieceSize", "pieces"], id: id)
+    }
+}
+
+internal extension TransmissionConnection {
+    func fetchTorrentSummary() async throws -> [Torrent] {
+        let response = try await sendRequiredArguments(
+            method: "torrent-get",
+            arguments: TransmissionTorrentQuerySpec.torrentSummary.arguments,
+            responseType: TorrentListResponse.self
+        )
+
+        return response.torrents
+    }
+
+    func fetchWidgetSummary() async throws -> [Torrent] {
+        let response = try await sendRequiredArguments(
+            method: "torrent-get",
+            arguments: TransmissionTorrentQuerySpec.widgetSummary.arguments,
+            responseType: TorrentListResponse.self
+        )
+
+        return response.torrents
+    }
+
+    func fetchTorrentFiles(id: Int) async throws -> TorrentFilesResponseData {
+        let response = try await sendRequiredArguments(
+            method: "torrent-get",
+            arguments: TransmissionTorrentQuerySpec.torrentFiles(id: id).arguments,
+            responseType: TorrentFilesResponseTorrents.self
+        )
+
+        guard let torrent = response.torrents.first else {
+            throw TransmissionError.invalidResponse
+        }
+
+        return torrent
+    }
+
+    func fetchTorrentPeers(id: Int) async throws -> TorrentPeersResponseData {
+        let response = try await sendRequiredArguments(
+            method: "torrent-get",
+            arguments: TransmissionTorrentQuerySpec.torrentPeers(id: id).arguments,
+            responseType: TorrentPeersResponseTorrents.self
+        )
+
+        guard let torrent = response.torrents.first else {
+            throw TransmissionError.invalidResponse
+        }
+
+        return torrent
+    }
+
+    func fetchTorrentPieces(id: Int) async throws -> TorrentPiecesResponseData {
+        let response = try await sendRequiredArguments(
+            method: "torrent-get",
+            arguments: TransmissionTorrentQuerySpec.torrentPieces(id: id).arguments,
+            responseType: TorrentPiecesResponseTorrents.self
+        )
+
+        guard let torrent = response.torrents.first else {
+            throw TransmissionError.invalidResponse
+        }
+
+        return torrent
+    }
+}

--- a/BitDream/Utilities.swift
+++ b/BitDream/Utilities.swift
@@ -247,18 +247,12 @@ func handleTransmissionResponse(
     onSuccess: @escaping () -> Void,
     onError: @escaping (String) -> Void
 ) {
-    switch response {
-    case .success:
+    guard let presentation = TransmissionLegacyCompatibility.presentation(for: response) else {
         onSuccess()
-    case .failed:
-        onError("Operation failed. Please try again.")
-    case .unauthorized:
-        onError("Authentication failed. Please check your server credentials.")
-    case .configError:
-        onError("Connection error. Please check your server settings.")
-    @unknown default:
-        onError("An unexpected error occurred. Please try again.")
+        return
     }
+
+    onError(presentation.message)
 }
 
 /// SwiftUI View modifier for displaying transmission error alerts

--- a/BitDream/Views/Shared/AddTorrent.swift
+++ b/BitDream/Views/Shared/AddTorrent.swift
@@ -47,10 +47,14 @@ func addTorrentAction(
         file: false,
         config: info.config,
         onAdd: { response in
-            if response.response == TransmissionResponse.success {
-                onSuccess?()
+            if let presentation = TransmissionLegacyCompatibility.presentation(for: response.response) {
+                handleAddTorrentError(
+                    "Failed to add torrent: \(presentation.message)",
+                    errorMessage: errorMessage,
+                    showingError: showingError
+                )
             } else {
-                handleAddTorrentError("Failed to add torrent: \(response.response)", errorMessage: errorMessage, showingError: showingError)
+                onSuccess?()
             }
         }
     )

--- a/BitDream/Views/macOS/macOSAddTorrent.swift
+++ b/BitDream/Views/macOS/macOSAddTorrent.swift
@@ -365,9 +365,9 @@ private extension macOSAddTorrent {
             file: true,
             config: info.config,
             onAdd: { response in
-                if response.response != TransmissionResponse.success {
+                if let presentation = TransmissionLegacyCompatibility.presentation(for: response.response) {
                     handleAddTorrentError(
-                        "Failed to add torrent: \(response.response)",
+                        "Failed to add torrent: \(presentation.message)",
                         errorMessage: $errorMessage,
                         showingError: $showingError
                     )

--- a/BitDream/Widgets/BackgroundRefresh/HostRefreshCatalogStore.swift
+++ b/BitDream/Widgets/BackgroundRefresh/HostRefreshCatalogStore.swift
@@ -163,3 +163,15 @@ actor HostRefreshCatalogStore {
         return base.appendingPathComponent(bundleID, isDirectory: true)
     }
 }
+
+extension TransmissionConnectionDescriptor {
+    init(record: HostRefreshRecord) {
+        self.init(
+            scheme: record.isSSL ? "https" : "http",
+            host: record.server,
+            port: record.port,
+            username: record.username,
+            credentialSource: .keychainCredential(record.credentialKey)
+        )
+    }
+}

--- a/BitDreamTests/Transmission/Connection/TransmissionConnectionFactoryTests.swift
+++ b/BitDreamTests/Transmission/Connection/TransmissionConnectionFactoryTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import BitDream
+
+final class TransmissionConnectionFactoryTests: XCTestCase {
+    func testFactoryRejectsInvalidEndpointDescriptor() async {
+        let factory = TransmissionConnectionFactory(
+            transport: TransmissionTransport(sender: QueueSender(steps: [])),
+            credentialResolver: TransmissionCredentialResolver(resolvePassword: { _ in "" })
+        )
+        let descriptor = TransmissionConnectionDescriptor(
+            scheme: "http",
+            host: "bad host",
+            port: 9091,
+            username: "demo",
+            credentialSource: .resolvedPassword("secret")
+        )
+
+        await assertThrowsTransmissionError(.invalidEndpointConfiguration) {
+            _ = try await factory.connection(for: descriptor)
+        }
+    }
+
+    func testFactoryResolvesKeychainCredentialSourceBeforeConstructingConnection() async throws {
+        let sender = QueueSender(steps: [
+            .http(statusCode: 200, body: successStatsBody)
+        ])
+        let factory = TransmissionConnectionFactory(
+            transport: TransmissionTransport(sender: sender),
+            credentialResolver: TransmissionCredentialResolver(resolvePassword: { source in
+                switch source {
+                case .resolvedPassword(let password):
+                    return password
+                case .keychainCredential(let key):
+                    return key == "widget-key" ? "resolved-secret" : ""
+                }
+            })
+        )
+        let descriptor = TransmissionConnectionDescriptor(
+            scheme: "https",
+            host: "example.com",
+            port: 9091,
+            username: "demo",
+            credentialSource: .keychainCredential("widget-key")
+        )
+
+        let connection = try await factory.connection(for: descriptor)
+        _ = try await connection.fetchSessionStats()
+
+        let requests = await sender.capturedRequests()
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(
+            requests[0].authorizationHeader,
+            "Basic \(Data("demo:resolved-secret".utf8).base64EncodedString())"
+        )
+    }
+
+    func testFactoryReusesConnectionForEquivalentResolvedDescriptor() async throws {
+        let factory = TransmissionConnectionFactory(
+            transport: TransmissionTransport(sender: QueueSender(steps: [])),
+            credentialResolver: TransmissionCredentialResolver(resolvePassword: { _ in "secret" })
+        )
+        let descriptor = TransmissionConnectionDescriptor(
+            scheme: "http",
+            host: "example.com",
+            port: 9091,
+            username: "demo",
+            credentialSource: .keychainCredential("credential-key")
+        )
+
+        let first = try await factory.connection(for: descriptor)
+        let second = try await factory.connection(for: descriptor)
+
+        XCTAssertEqual(ObjectIdentifier(first), ObjectIdentifier(second))
+    }
+
+    func testHostAndHostRefreshRecordProduceEquivalentDescriptors() {
+        let host = Host(
+            serverID: "server-1",
+            isDefault: false,
+            isSSL: true,
+            credentialKey: "credential-key",
+            name: "Server",
+            port: 9091,
+            server: "example.com",
+            username: "demo",
+            version: nil
+        )
+        let record = HostRefreshRecord(
+            serverID: "server-1",
+            name: "Server",
+            server: "example.com",
+            port: 9091,
+            username: "demo",
+            isSSL: true,
+            credentialKey: "credential-key",
+            isDefault: false,
+            version: nil
+        )
+
+        XCTAssertEqual(
+            TransmissionConnectionDescriptor(host: host),
+            TransmissionConnectionDescriptor(record: record)
+        )
+    }
+
+    func testLegacyTupleDescriptorBridgeUsesResolvedPasswordSource() {
+        let descriptor = TransmissionConnectionDescriptor(config: makeConfig(), auth: makeAuth())
+
+        XCTAssertEqual(descriptor.scheme, "http")
+        XCTAssertEqual(descriptor.host, "example.com")
+        XCTAssertEqual(descriptor.port, 9091)
+        XCTAssertEqual(descriptor.username, "demo")
+        XCTAssertEqual(descriptor.credentialSource, .resolvedPassword("secret"))
+    }
+}

--- a/BitDreamTests/Transmission/Connection/TransmissionConnectionQueryTests.swift
+++ b/BitDreamTests/Transmission/Connection/TransmissionConnectionQueryTests.swift
@@ -1,0 +1,216 @@
+import XCTest
+@testable import BitDream
+
+final class TransmissionConnectionQueryTests: XCTestCase {
+    func testFetchTorrentSummaryUsesNamedSummaryFieldsAndDecodesTorrents() async throws {
+        let sender = QueueSender(steps: [
+            .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json"))
+        ])
+        let connection = TransmissionConnection(
+            endpoint: try makeEndpoint(),
+            auth: makeAuth(),
+            transport: TransmissionTransport(sender: sender)
+        )
+
+        let torrents = try await connection.fetchTorrentSummary()
+
+        XCTAssertFalse(torrents.isEmpty)
+        let requests = await sender.capturedRequests()
+        XCTAssertEqual(try capturedRequestFields(requests[0]), TransmissionTorrentQuerySpec.torrentSummary.fields)
+    }
+
+    func testFetchWidgetSummaryUsesNamedWidgetFields() async throws {
+        let sender = QueueSender(steps: [
+            .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json"))
+        ])
+        let connection = TransmissionConnection(
+            endpoint: try makeEndpoint(),
+            auth: makeAuth(),
+            transport: TransmissionTransport(sender: sender)
+        )
+
+        _ = try await connection.fetchWidgetSummary()
+
+        let requests = await sender.capturedRequests()
+        XCTAssertEqual(try capturedRequestFields(requests[0]), TransmissionTorrentQuerySpec.widgetSummary.fields)
+    }
+
+    func testFetchTorrentFilesUsesNamedFieldsAndDecodesFirstTorrent() async throws {
+        let sender = QueueSender(steps: [
+            .http(
+                statusCode: 200,
+                body: """
+                {
+                  "arguments": {
+                    "torrents": [
+                      {
+                        "files": [
+                          { "bytesCompleted": 1, "length": 2, "name": "Ubuntu.iso" }
+                        ],
+                        "fileStats": [
+                          { "bytesCompleted": 1, "wanted": true, "priority": 0 }
+                        ]
+                      }
+                    ]
+                  },
+                  "result": "success"
+                }
+                """
+            )
+        ])
+        let connection = TransmissionConnection(
+            endpoint: try makeEndpoint(),
+            auth: makeAuth(),
+            transport: TransmissionTransport(sender: sender)
+        )
+
+        let response = try await connection.fetchTorrentFiles(id: 42)
+
+        XCTAssertEqual(response.files.first?.name, "Ubuntu.iso")
+        let requests = await sender.capturedRequests()
+        XCTAssertEqual(try capturedRequestFields(requests[0]), TransmissionTorrentQuerySpec.torrentFiles(id: 42).fields)
+    }
+
+    func testFetchTorrentPeersUsesNamedFieldsAndDecodesFirstTorrent() async throws {
+        let sender = QueueSender(steps: [
+            .http(
+                statusCode: 200,
+                body: makeTorrentPeersSuccessBody()
+            )
+        ])
+        let connection = TransmissionConnection(
+            endpoint: try makeEndpoint(),
+            auth: makeAuth(),
+            transport: TransmissionTransport(sender: sender)
+        )
+
+        let response = try await connection.fetchTorrentPeers(id: 42)
+
+        XCTAssertEqual(response.peers.first?.clientName, "Transmission")
+        let requests = await sender.capturedRequests()
+        XCTAssertEqual(try capturedRequestFields(requests[0]), TransmissionTorrentQuerySpec.torrentPeers(id: 42).fields)
+    }
+
+    func testFetchTorrentPiecesUsesNamedFieldsAndDecodesFirstTorrent() async throws {
+        let sender = QueueSender(steps: [
+            .http(
+                statusCode: 200,
+                body: """
+                {
+                  "arguments": {
+                    "torrents": [
+                      {
+                        "pieceCount": 2,
+                        "pieceSize": 16384,
+                        "pieces": "Zm9v"
+                      }
+                    ]
+                  },
+                  "result": "success"
+                }
+                """
+            )
+        ])
+        let connection = TransmissionConnection(
+            endpoint: try makeEndpoint(),
+            auth: makeAuth(),
+            transport: TransmissionTransport(sender: sender)
+        )
+
+        let response = try await connection.fetchTorrentPieces(id: 42)
+
+        XCTAssertEqual(response.pieces, "Zm9v")
+        let requests = await sender.capturedRequests()
+        XCTAssertEqual(try capturedRequestFields(requests[0]), TransmissionTorrentQuerySpec.torrentPieces(id: 42).fields)
+    }
+
+    func testFetchSessionStatsDecodesResponse() async throws {
+        let sender = QueueSender(steps: [
+            .http(statusCode: 200, body: successStatsBody)
+        ])
+        let connection = TransmissionConnection(
+            endpoint: try makeEndpoint(),
+            auth: makeAuth(),
+            transport: TransmissionTransport(sender: sender)
+        )
+
+        let stats = try await connection.fetchSessionStats()
+
+        XCTAssertEqual(stats.torrentCount, 4)
+    }
+
+    func testFetchSessionSettingsUsesNamedFieldsAndDecodesArguments() async throws {
+        let sender = QueueSender(steps: [
+            .http(statusCode: 200, body: try loadTransmissionFixture(named: "session-get.response.json"))
+        ])
+        let connection = TransmissionConnection(
+            endpoint: try makeEndpoint(),
+            auth: makeAuth(),
+            transport: TransmissionTransport(sender: sender)
+        )
+
+        let settings = try await connection.fetchSessionSettings()
+
+        XCTAssertFalse(settings.downloadDir.isEmpty)
+        let requests = await sender.capturedRequests()
+        XCTAssertEqual(try capturedRequestFields(requests[0]), TransmissionSessionQuerySpec.sessionSettings.fields)
+    }
+
+    func testQueryMethodsPropagateTransmissionErrors() async throws {
+        let sender = QueueSender(steps: [
+            .http(statusCode: 200, body: #"{"result":"server busy","arguments":{}}"#)
+        ])
+        let connection = TransmissionConnection(
+            endpoint: try makeEndpoint(),
+            auth: makeAuth(),
+            transport: TransmissionTransport(sender: sender)
+        )
+
+        await assertThrowsTransmissionError(.rpcFailure(expectedResult: "server busy")) {
+            _ = try await connection.fetchTorrentSummary()
+        }
+    }
+}
+
+private func makeTorrentPeersSuccessBody() -> String {
+    """
+    {
+      "arguments": {
+        "torrents": [
+          {
+            "peers": [
+              {
+                "address": "127.0.0.1",
+                "clientName": "Transmission",
+                "clientIsChoked": false,
+                "clientIsInterested": true,
+                "flagStr": "D",
+                "isDownloadingFrom": true,
+                "isEncrypted": false,
+                "isIncoming": false,
+                "isUploadingTo": false,
+                "isUTP": false,
+                "peerIsChoked": false,
+                "peerIsInterested": true,
+                "port": 51413,
+                "progress": 0.5,
+                "rateToClient": 100,
+                "rateToPeer": 200
+              }
+            ],
+            "peersFrom": {
+              "fromCache": 0,
+              "fromDht": 1,
+              "fromIncoming": 0,
+              "fromLpd": 0,
+              "fromLtep": 0,
+              "fromPex": 0,
+              "fromTracker": 1
+            }
+          }
+        ]
+      },
+      "result": "success"
+    }
+    """
+}

--- a/BitDreamTests/Transmission/Legacy/TransmissionCompatibilityAdapterQueryTests.swift
+++ b/BitDreamTests/Transmission/Legacy/TransmissionCompatibilityAdapterQueryTests.swift
@@ -1,0 +1,199 @@
+import XCTest
+@testable import BitDream
+
+final class TransmissionAdapterQueryTests: XCTestCase {
+    func testFetchTorrentSummaryReturnsTorrents() async throws {
+        let adapter = makeLegacyAdapter(steps: [
+            .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json"))
+        ])
+
+        let result = await adapter.fetchTorrentSummary(config: makeConfig(), auth: makeAuth())
+
+        switch result {
+        case .success(let torrents):
+            XCTAssertFalse(torrents.isEmpty)
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+
+    func testFetchWidgetSummaryReturnsTorrents() async throws {
+        let adapter = makeLegacyAdapter(steps: [
+            .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json"))
+        ])
+
+        let result = await adapter.fetchWidgetSummary(config: makeConfig(), auth: makeAuth())
+
+        switch result {
+        case .success(let torrents):
+            XCTAssertFalse(torrents.isEmpty)
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+
+    func testFetchTorrentFilesReturnsFirstTorrentPayload() async {
+        let adapter = makeLegacyAdapter(steps: [
+            .http(
+                statusCode: 200,
+                body: """
+                {
+                  "arguments": {
+                    "torrents": [
+                      {
+                        "files": [
+                          { "bytesCompleted": 1, "length": 2, "name": "Ubuntu.iso" }
+                        ],
+                        "fileStats": [
+                          { "bytesCompleted": 1, "wanted": true, "priority": 0 }
+                        ]
+                      }
+                    ]
+                  },
+                  "result": "success"
+                }
+                """
+            )
+        ])
+
+        let result = await adapter.fetchTorrentFiles(
+            transferID: 42,
+            config: makeConfig(),
+            auth: makeAuth()
+        )
+
+        switch result {
+        case .success(let response):
+            XCTAssertEqual(response.files.first?.name, "Ubuntu.iso")
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+
+    func testFetchTorrentPeersReturnsFirstTorrentPayload() async {
+        let adapter = makeLegacyAdapter(steps: [
+            .http(statusCode: 200, body: makeCompatibilityTorrentPeersSuccessBody())
+        ])
+
+        let result = await adapter.fetchTorrentPeers(
+            transferID: 42,
+            config: makeConfig(),
+            auth: makeAuth()
+        )
+
+        switch result {
+        case .success(let response):
+            XCTAssertEqual(response.peers.first?.clientName, "Transmission")
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+
+    func testFetchTorrentPiecesReturnsFirstTorrentPayload() async {
+        let adapter = makeLegacyAdapter(steps: [
+            .http(
+                statusCode: 200,
+                body: """
+                {
+                  "arguments": {
+                    "torrents": [
+                      {
+                        "pieceCount": 2,
+                        "pieceSize": 16384,
+                        "pieces": "Zm9v"
+                      }
+                    ]
+                  },
+                  "result": "success"
+                }
+                """
+            )
+        ])
+
+        let result = await adapter.fetchTorrentPieces(
+            transferID: 42,
+            config: makeConfig(),
+            auth: makeAuth()
+        )
+
+        switch result {
+        case .success(let response):
+            XCTAssertEqual(response.pieces, "Zm9v")
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+
+    func testFetchSessionStatsReturnsStats() async {
+        let adapter = makeLegacyAdapter(steps: [
+            .http(statusCode: 200, body: successStatsBody)
+        ])
+
+        let result = await adapter.fetchSessionStats(config: makeConfig(), auth: makeAuth())
+
+        switch result {
+        case .success(let stats):
+            XCTAssertEqual(stats.torrentCount, 4)
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+
+    func testFetchSessionSettingsReturnsSettings() async throws {
+        let adapter = makeLegacyAdapter(steps: [
+            .http(statusCode: 200, body: try loadTransmissionFixture(named: "session-get.response.json"))
+        ])
+
+        let result = await adapter.fetchSessionSettings(config: makeConfig(), auth: makeAuth())
+
+        switch result {
+        case .success(let settings):
+            XCTAssertFalse(settings.downloadDir.isEmpty)
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+}
+
+private func makeCompatibilityTorrentPeersSuccessBody() -> String {
+    """
+    {
+      "arguments": {
+        "torrents": [
+          {
+            "peers": [
+              {
+                "address": "127.0.0.1",
+                "clientName": "Transmission",
+                "clientIsChoked": false,
+                "clientIsInterested": true,
+                "flagStr": "D",
+                "isDownloadingFrom": true,
+                "isEncrypted": false,
+                "isIncoming": false,
+                "isUploadingTo": false,
+                "isUTP": false,
+                "peerIsChoked": false,
+                "peerIsInterested": true,
+                "port": 51413,
+                "progress": 0.5,
+                "rateToClient": 100,
+                "rateToPeer": 200
+              }
+            ],
+            "peersFrom": {
+              "fromCache": 0,
+              "fromDht": 1,
+              "fromIncoming": 0,
+              "fromLpd": 0,
+              "fromLtep": 0,
+              "fromPex": 0,
+              "fromTracker": 1
+            }
+          }
+        ]
+      },
+      "result": "success"
+    }
+    """
+}

--- a/BitDreamTests/Transmission/Legacy/TransmissionCompatibilityAdapterStatusTests.swift
+++ b/BitDreamTests/Transmission/Legacy/TransmissionCompatibilityAdapterStatusTests.swift
@@ -1,10 +1,10 @@
 import XCTest
 @testable import BitDream
 
-// TODO: Remove this suite when the temporary compatibility adapter is deleted.
-final class TransmissionCompatibilityAdapterTests: XCTestCase {
+// TODO: Remove these suites when the temporary compatibility adapter is deleted.
+final class TransmissionAdapterStatusTests: XCTestCase {
     func testStatusRequestMapsRPCFailureToFailed() async {
-        let adapter = makeAdapter(steps: [
+        let adapter = makeLegacyAdapter(steps: [
             .http(statusCode: 200, body: #"{"result":"queue move failed","arguments":{}}"#)
         ])
 
@@ -19,7 +19,7 @@ final class TransmissionCompatibilityAdapterTests: XCTestCase {
     }
 
     func testStatusRequestMapsUnauthorizedToUnauthorized() async {
-        let adapter = makeAdapter(steps: [
+        let adapter = makeLegacyAdapter(steps: [
             .http(statusCode: 401, body: "")
         ])
 
@@ -37,7 +37,7 @@ final class TransmissionCompatibilityAdapterTests: XCTestCase {
         var config = makeConfig()
         config.host = "bad host"
 
-        let adapter = makeAdapter(steps: [])
+        let adapter = makeLegacyAdapter(steps: [])
         let response = await adapter.performStatusRequest(
             method: "torrent-stop",
             args: EmptyArguments(),
@@ -49,7 +49,7 @@ final class TransmissionCompatibilityAdapterTests: XCTestCase {
     }
 
     func testStatusRequestMapsTimeoutToConfigError() async {
-        let adapter = makeAdapter(steps: [
+        let adapter = makeLegacyAdapter(steps: [
             .error(URLError(.timedOut))
         ])
 
@@ -64,7 +64,7 @@ final class TransmissionCompatibilityAdapterTests: XCTestCase {
     }
 
     func testStatusRequestInherits409RetryBehaviorFromTransport() async {
-        let adapter = makeAdapter(steps: [
+        let adapter = makeLegacyAdapter(steps: [
             .http(statusCode: 409, body: "", headers: [transmissionSessionTokenHeader: "fresh-token"]),
             .http(statusCode: 200, body: successEmptyBody)
         ])
@@ -80,7 +80,7 @@ final class TransmissionCompatibilityAdapterTests: XCTestCase {
     }
 
     func testTorrentAddAddedOutcomeReturnsSuccessAndID() async {
-        let adapter = makeAdapter(steps: [
+        let adapter = makeLegacyAdapter(steps: [
             .http(
                 statusCode: 200,
                 body: """
@@ -109,7 +109,7 @@ final class TransmissionCompatibilityAdapterTests: XCTestCase {
     }
 
     func testTorrentAddDuplicateOutcomeReturnsSuccessAndID() async {
-        let adapter = makeAdapter(steps: [
+        let adapter = makeLegacyAdapter(steps: [
             .http(
                 statusCode: 200,
                 body: """
@@ -138,7 +138,7 @@ final class TransmissionCompatibilityAdapterTests: XCTestCase {
     }
 
     func testTorrentAddMalformedSuccessPayloadFails() async {
-        let adapter = makeAdapter(steps: [
+        let adapter = makeLegacyAdapter(steps: [
             .http(statusCode: 200, body: #"{"result":"success","arguments":{}}"#)
         ])
 
@@ -153,7 +153,7 @@ final class TransmissionCompatibilityAdapterTests: XCTestCase {
     }
 
     func testDataRequestReturnsDecodedArguments() async throws {
-        let adapter = makeAdapter(steps: [
+        let adapter = makeLegacyAdapter(steps: [
             .http(statusCode: 200, body: successStatsBody)
         ])
 
@@ -174,7 +174,7 @@ final class TransmissionCompatibilityAdapterTests: XCTestCase {
     }
 
     func testDataRequestWrapsFailuresInCompatibilityError() async {
-        let adapter = makeAdapter(steps: [
+        let adapter = makeLegacyAdapter(steps: [
             .http(statusCode: 200, body: #"{"result":"server busy","arguments":{}}"#)
         ])
 
@@ -195,12 +195,4 @@ final class TransmissionCompatibilityAdapterTests: XCTestCase {
             XCTAssertEqual(error.localizedDescription, "server busy")
         }
     }
-
-    private func makeAdapter(steps: [QueueSender.Step]) -> TransmissionLegacyAdapter {
-        TransmissionLegacyAdapter(
-            transport: TransmissionTransport(sender: QueueSender(steps: steps))
-        )
-    }
 }
-
-private let successEmptyBody = #"{"result":"success","arguments":{}}"#

--- a/BitDreamTests/Transmission/Legacy/TransmissionCompatibilityAdapterTestSupport.swift
+++ b/BitDreamTests/Transmission/Legacy/TransmissionCompatibilityAdapterTestSupport.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import BitDream
+
+func makeLegacyAdapter(steps: [QueueSender.Step]) -> TransmissionLegacyAdapter {
+    TransmissionLegacyAdapter(
+        transport: TransmissionTransport(sender: QueueSender(steps: steps))
+    )
+}
+
+let successEmptyBody = #"{"result":"success","arguments":{}}"#

--- a/BitDreamTests/Transmission/Legacy/TransmissionErrorPresentationTests.swift
+++ b/BitDreamTests/Transmission/Legacy/TransmissionErrorPresentationTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import BitDream
+
+final class TransmissionErrorPresentationTests: XCTestCase {
+    func testPresentationMapsEveryTransmissionErrorCase() {
+        XCTAssertEqual(
+            TransmissionErrorPresenter.presentation(for: .invalidEndpointConfiguration),
+            TransmissionErrorPresentation(
+                title: "Connection Error",
+                message: "Connection error. Please check your server settings."
+            )
+        )
+        XCTAssertEqual(
+            TransmissionErrorPresenter.presentation(for: .unauthorized),
+            TransmissionErrorPresentation(
+                title: "Authentication Failed",
+                message: "Authentication failed. Please check your server credentials."
+            )
+        )
+        XCTAssertEqual(
+            TransmissionErrorPresenter.presentation(for: .transport(underlyingDescription: "Offline")),
+            TransmissionErrorPresentation(title: "Connection Error", message: "Offline")
+        )
+        XCTAssertEqual(
+            TransmissionErrorPresenter.presentation(for: .timeout),
+            TransmissionErrorPresentation(title: "Connection Timed Out", message: "The request timed out.")
+        )
+        XCTAssertEqual(
+            TransmissionErrorPresenter.presentation(for: .cancelled),
+            TransmissionErrorPresentation(title: "Request Cancelled", message: "The request was cancelled.")
+        )
+        XCTAssertEqual(
+            TransmissionErrorPresenter.presentation(for: .httpStatus(code: 500, body: nil)),
+            TransmissionErrorPresentation(title: "Server Error", message: "Server returned HTTP 500.")
+        )
+        XCTAssertEqual(
+            TransmissionErrorPresenter.presentation(for: .rpcFailure(result: "busy")),
+            TransmissionErrorPresentation(title: "Operation Failed", message: "busy")
+        )
+        XCTAssertEqual(
+            TransmissionErrorPresenter.presentation(for: .invalidResponse),
+            TransmissionErrorPresentation(title: "Server Error", message: "The server returned an invalid response.")
+        )
+        XCTAssertEqual(
+            TransmissionErrorPresenter.presentation(for: .decoding(underlyingDescription: "bad json")),
+            TransmissionErrorPresentation(title: "Server Error", message: "Failed to decode the server response.")
+        )
+    }
+
+    func testLegacyResponseMappingMatchesCompatibilityContract() {
+        XCTAssertEqual(TransmissionLegacyCompatibility.response(from: .unauthorized), .unauthorized)
+        XCTAssertEqual(TransmissionLegacyCompatibility.response(from: .invalidEndpointConfiguration), .configError)
+        XCTAssertEqual(TransmissionLegacyCompatibility.response(from: .timeout), .configError)
+        XCTAssertEqual(TransmissionLegacyCompatibility.response(from: .rpcFailure(result: "busy")), .failed)
+        XCTAssertEqual(TransmissionLegacyCompatibility.response(from: .httpStatus(code: 500, body: nil)), .failed)
+        XCTAssertEqual(TransmissionLegacyCompatibility.response(from: .invalidResponse), .failed)
+        XCTAssertEqual(TransmissionLegacyCompatibility.response(from: .decoding(underlyingDescription: "bad json")), .failed)
+    }
+
+    func testLegacyLocalizedErrorUsesPresentationMessage() {
+        let error = TransmissionLegacyCompatibility.localizedError(
+            from: TransmissionError.rpcFailure(result: "server busy")
+        )
+
+        XCTAssertTrue(error is TransmissionLegacyCompatibilityError)
+        XCTAssertEqual(error.localizedDescription, "server busy")
+    }
+
+    func testLegacyResponsePresentationRemainsStable() {
+        XCTAssertNil(TransmissionLegacyCompatibility.presentation(for: .success))
+        XCTAssertEqual(
+            TransmissionLegacyCompatibility.presentation(for: .unauthorized),
+            TransmissionErrorPresentation(
+                title: "Authentication Failed",
+                message: "Authentication failed. Please check your server credentials."
+            )
+        )
+        XCTAssertEqual(
+            TransmissionLegacyCompatibility.presentation(for: .configError),
+            TransmissionErrorPresentation(
+                title: "Connection Error",
+                message: "Connection error. Please check your server settings."
+            )
+        )
+        XCTAssertEqual(
+            TransmissionLegacyCompatibility.presentation(for: .failed),
+            TransmissionErrorPresentation(
+                title: "Operation Failed",
+                message: "Operation failed. Please try again."
+            )
+        )
+    }
+}

--- a/BitDreamTests/Transmission/TransmissionTestSupport.swift
+++ b/BitDreamTests/Transmission/TransmissionTestSupport.swift
@@ -204,6 +204,28 @@ struct CapturedRequest: Sendable {
     }
 }
 
+func capturedRequestFields(_ request: CapturedRequest) throws -> [String] {
+    let body = try XCTUnwrap(request.body)
+    let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    let arguments = try XCTUnwrap(object["arguments"] as? [String: Any])
+    return try XCTUnwrap(arguments["fields"] as? [String])
+}
+
+func loadTransmissionFixture(named fileName: String) throws -> String {
+    let testFileURL = URL(fileURLWithPath: #filePath)
+    let fixturesURL = testFileURL
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("BitDream")
+        .appendingPathComponent("Transmission")
+        .appendingPathComponent("TransmissionRPC")
+        .appendingPathComponent("Examples")
+        .appendingPathComponent(fileName)
+
+    return try String(contentsOf: fixturesURL, encoding: .utf8)
+}
+
 enum TestError: Error {
     case offline
     case unexpectedRequest


### PR DESCRIPTION
## Summary

Refactors the Transmission client surface so callers can move onto the new connection boundary without relying on the old helper architecture.

## What Changed

- adds a shared `TransmissionConnectionDescriptor` and `TransmissionConnectionFactory` for consistent endpoint validation, credential resolution, and connection reuse
- adds named torrent and session query methods on `TransmissionConnection`
- centralizes app-side Transmission error presentation and legacy error conversion
- reduces legacy Transmission helpers and adapters to shim behavior over the new connection surface
- adds focused Transmission tests for connection construction, query behavior, compatibility mapping, and error presentation