### PR TITLE
Migrate app target to file-system-synchronized groups

### DIFF
--- a/BitDream.xcodeproj/project.pbxproj
+++ b/BitDream.xcodeproj/project.pbxproj
@@ -7,110 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4B1DADDF295E6C440037E9FB /* BitDreamApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DADDE295E6C440037E9FB /* BitDreamApp.swift */; };
-		4B1DADE1295E6C440037E9FB /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DADE0295E6C440037E9FB /* PersistenceController.swift */; };
-		4B1DADE6295E6C440037E9FB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DADE5295E6C440037E9FB /* ContentView.swift */; };
-		4B1DADE8295E6C450037E9FB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4B1DADE7295E6C450037E9FB /* Assets.xcassets */; };
-		4B1DADEC295E6C450037E9FB /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4B1DADEB295E6C450037E9FB /* Preview Assets.xcassets */; };
-		4B1DADFE295E6F390037E9FB /* TransmissionTorrentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DADFD295E6F390037E9FB /* TransmissionTorrentModels.swift */; };
-		4B1DAE02295E6FA30037E9FB /* AddTorrent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DAE01295E6FA30037E9FB /* AddTorrent.swift */; };
-		4B1DAE06295E6FC80037E9FB /* TorrentDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DAE05295E6FC80037E9FB /* TorrentDetail.swift */; };
-		4B1DAE0A295E6FE10037E9FB /* ServerDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DAE09295E6FE10037E9FB /* ServerDetail.swift */; };
-		4B1DAE0C295E6FEF0037E9FB /* ServerList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DAE0B295E6FEF0037E9FB /* ServerList.swift */; };
-		4B1DAE0E295E6FFB0037E9FB /* ErrorDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DAE0D295E6FFB0037E9FB /* ErrorDialog.swift */; };
-		4B1DAE10295E702B0037E9FB /* TransmissionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DAE0F295E702B0037E9FB /* TransmissionStore.swift */; };
-		4B4E4C1B2E8A1F6E00418FD7 /* BitDreamAppIconBlue.icon in Resources */ = {isa = PBXBuildFile; fileRef = 4B4E4C182E8A1F6E00418FD7 /* BitDreamAppIconBlue.icon */; };
-		4B4E4C1C2E8A1F6E00418FD7 /* BitDreamAppIconDefault.icon in Resources */ = {isa = PBXBuildFile; fileRef = 4B4E4C192E8A1F6E00418FD7 /* BitDreamAppIconDefault.icon */; };
-		4B4E4C8A2E8A2B4D00418FD7 /* AppIconCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4E4C892E8A2B4D00418FD7 /* AppIconCatalog.swift */; };
-		4B61EA9D2E8A396D005BD750 /* BitDreamAppIconPinkBg.icon in Resources */ = {isa = PBXBuildFile; fileRef = 4B61EA9C2E8A396D005BD750 /* BitDreamAppIconPinkBg.icon */; };
-		4B642D6C2D7E151A003CEADC /* macOSServerDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B642D6B2D7E151A003CEADC /* macOSServerDetail.swift */; };
-		4B642D6D2D7E151A003CEADC /* iOSServerDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B642D6A2D7E151A003CEADC /* iOSServerDetail.swift */; };
-		4B642D792D7E1EED003CEADC /* macOSServerList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B642D782D7E1EED003CEADC /* macOSServerList.swift */; };
-		4B642D7B2D7E1EF6003CEADC /* iOSServerList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B642D7A2D7E1EF6003CEADC /* iOSServerList.swift */; };
-		4B6F1EA62D82BD4A003D8F6E /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F1EA52D82BD4A003D8F6E /* SettingsView.swift */; };
-		4B6F1EAE2D82D337003D8F6E /* macOSSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F1EAD2D82D337003D8F6E /* macOSSettingsView.swift */; };
-		4B6F1EB02D82D340003D8F6E /* iOSSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F1EAF2D82D340003D8F6E /* iOSSettingsView.swift */; };
-		4B6F1EB22D82DB21003D8F6E /* TorrentListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F1EB12D82DB21003D8F6E /* TorrentListRow.swift */; };
-		4B6F1EB42D82DB2D003D8F6E /* iOSTorrentListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F1EB32D82DB2D003D8F6E /* iOSTorrentListRow.swift */; };
-		4B6F1EBC2D86C908003D8F6E /* macOSTorrentFileDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F1EBB2D86C908003D8F6E /* macOSTorrentFileDetail.swift */; };
-		4B6F1EBE2D86C926003D8F6E /* iOSTorrentFileDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F1EBD2D86C926003D8F6E /* iOSTorrentFileDetail.swift */; };
-		4B6F1EC02D86D52A003D8F6E /* TorrentFileDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F1EBF2D86D52A003D8F6E /* TorrentFileDetail.swift */; };
-		4B73985C2E70097C00D06E5D /* AppFileOpenDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B73985A2E70097C00D06E5D /* AppFileOpenDelegate.swift */; };
-		4B73985E2E70181D00D06E5D /* macOSStatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B73985D2E70181D00D06E5D /* macOSStatisticsView.swift */; };
-		4B7398602E7029BD00D06E5D /* macOSAboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B73985F2E7029BD00D06E5D /* macOSAboutView.swift */; };
-		4B73986C2F1A112200D06E5D /* macOSConnectionInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B73986B2F1A112200D06E5D /* macOSConnectionInfoView.swift */; };
-		4B7EF5712E6E9F0C00C1C281 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7EF5702E6E9F0C00C1C281 /* AppConfig.swift */; };
-		4B8670062E73DE6E0004ECBA /* AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDACD502E73DBBE0074F714 /* AppGroup.swift */; };
-		4B9CAC542D7E833A0094CD03 /* macOSAddTorrent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9CAC532D7E833A0094CD03 /* macOSAddTorrent.swift */; };
-		4B9CAC562D7E83460094CD03 /* iOSAddTorrent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9CAC552D7E83460094CD03 /* iOSAddTorrent.swift */; };
-		4BC2C92A2E6E22B800011971 /* macOSTorrentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC2C9272E6E22B800011971 /* macOSTorrentList.swift */; };
-		4BC2C92B2E6E22B800011971 /* macOSTorrentListExpanded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC2C9292E6E22B800011971 /* macOSTorrentListExpanded.swift */; };
-		4BC2C92C2E6E22B800011971 /* macOSTorrentListCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC2C9282E6E22B800011971 /* macOSTorrentListCompact.swift */; };
-		4BC4A4BA2E7248A300578D08 /* macOSMenuCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC4A4B92E7248A300578D08 /* macOSMenuCommands.swift */; };
-		4BC5C2AA2D7D20B500D80AB4 /* iOSContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC5C2A72D7D20B500D80AB4 /* iOSContentView.swift */; };
-		4BC5C2AC2D7D20B500D80AB4 /* macOSContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC5C2A82D7D20B500D80AB4 /* macOSContentView.swift */; };
-		4BC5C2B32D7D415100D80AB4 /* macOSTorrentDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC5C2B22D7D415100D80AB4 /* macOSTorrentDetail.swift */; };
-		4BC5C2B42D7D415100D80AB4 /* iOSTorrentDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC5C2B12D7D415100D80AB4 /* iOSTorrentDetail.swift */; };
-		4BC6F24B2E89F8510037DFDF /* PiecesGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC6F24A2E89F8510037DFDF /* PiecesGridView.swift */; };
-		4BCF274F2E774EDC00F6BF76 /* DataWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BCF274E2E774EDC00F6BF76 /* DataWriter.swift */; };
-		4BCF27502E774EDC00F6BF76 /* DataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BCF274D2E774EDC00F6BF76 /* DataModels.swift */; };
-		4BCF27512E774F3E00F6BF76 /* DataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BCF274D2E774EDC00F6BF76 /* DataModels.swift */; };
-		4BD8554A2E77424B00606224 /* WidgetKitBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD855492E77424B00606224 /* WidgetKitBridge.swift */; };
-		4BD8554B2E77424B00606224 /* WidgetKitBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD855492E77424B00606224 /* WidgetKitBridge.swift */; };
-		4BD938EB2D82AF6F006CE97C /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD938E92D82AF6F006CE97C /* ThemeManager.swift */; };
-		4BDA6AA92E8AD06D009E6098 /* BitDreamAppIconPixelyClouds.icon in Resources */ = {isa = PBXBuildFile; fileRef = 4BDA6AA82E8AD06D009E6098 /* BitDreamAppIconPixelyClouds.icon */; };
+		4B8670062E73DE6E0004ECBA /* BitDream/Widgets/AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDACD502E73DBBE0074F714 /* BitDream/Widgets/AppGroup.swift */; };
+		4BCF27512E774F3E00F6BF76 /* BitDream/Widgets/DataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BCF274D2E774EDC00F6BF76 /* BitDream/Widgets/DataModels.swift */; };
+		4BD8554A2E77424B00606224 /* BitDream/Widgets/WidgetKitBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD855492E77424B00606224 /* BitDream/Widgets/WidgetKitBridge.swift */; };
 		4BDACD172E73DB220074F714 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BDACD162E73DB220074F714 /* WidgetKit.framework */; };
 		4BDACD192E73DB220074F714 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BDACD182E73DB220074F714 /* SwiftUI.framework */; };
 		4BDACD2A2E73DB230074F714 /* BitDreamWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 4BDACD142E73DB220074F714 /* BitDreamWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		4BDACD572E73DBBE0074F714 /* AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDACD502E73DBBE0074F714 /* AppGroup.swift */; };
-		4BDE147F2F0B015C00FF6A46 /* AppIconManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDE147E2F0B015C00FF6A46 /* AppIconManager.swift */; };
-		4BE364BA2E6E75B300CF1A33 /* SharedComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE364B92E6E75B300CF1A33 /* SharedComponents.swift */; };
-		4BEFEE7C2E6E5E69005815FA /* ContentTypeIconMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEFEE7B2E6E5E69005815FA /* ContentTypeIconMapper.swift */; };
-		4BF593B72E89BF5500A8C1FC /* macOSTorrentPeerDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF593B62E89BF5500A8C1FC /* macOSTorrentPeerDetail.swift */; };
-		4BF593B92E89BF6300A8C1FC /* TorrentPeerDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF593B82E89BF6300A8C1FC /* TorrentPeerDetail.swift */; };
-		4BF593BB2E89C8C400A8C1FC /* iOSTorrentPeerDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF593BA2E89C8C400A8C1FC /* iOSTorrentPeerDetail.swift */; };
-		4BFFAA012E7F000000000001 /* macOSTorrentActionsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFFAA002E7F000000000001 /* macOSTorrentActionsMenu.swift */; };
-		4C1000113A00000000A1B2C3 /* MenuBarTorrentSelectors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1000013A00000000A1B2C3 /* MenuBarTorrentSelectors.swift */; };
-		4C1000123A00000000A1B2C3 /* macOSMenuBarTorrentRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1000023A00000000A1B2C3 /* macOSMenuBarTorrentRow.swift */; };
-		4C1000133A00000000A1B2C3 /* macOSMenuBarTorrentWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1000033A00000000A1B2C3 /* macOSMenuBarTorrentWidget.swift */; };
-		4C1000143A00000000A1B2C3 /* ConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1000043A00000000A1B2C3 /* ConnectionStatus.swift */; };
-		4C1000153A00000000A1B2C3 /* MenuBarStatusItemBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1000053A00000000A1B2C3 /* MenuBarStatusItemBridge.swift */; };
-		4C2000053C00000000A1B2C3 /* macOSGeneralSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2000013C00000000A1B2C3 /* macOSGeneralSettingsTab.swift */; };
-		4C2000063C00000000A1B2C3 /* macOSTorrentSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2000023C00000000A1B2C3 /* macOSTorrentSettingsTab.swift */; };
-		4C2000073C00000000A1B2C3 /* macOSSpeedLimitsSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2000033C00000000A1B2C3 /* macOSSpeedLimitsSettingsTab.swift */; };
-		4C2000083C00000000A1B2C3 /* macOSNetworkSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2000043C00000000A1B2C3 /* macOSNetworkSettingsTab.swift */; };
-		4C3000073C10000000A1B2C3 /* iOSTorrentsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3000033C10000000A1B2C3 /* iOSTorrentsSettingsView.swift */; };
-		4C3000083C10000000A1B2C3 /* iOSSpeedLimitsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3000043C10000000A1B2C3 /* iOSSpeedLimitsSettingsView.swift */; };
-		4C3000093C10000000A1B2C3 /* iOSNetworkSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3000053C10000000A1B2C3 /* iOSNetworkSettingsView.swift */; };
 		4D1000013B00000000B1C2D3 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; platformFilters = (macos, ); productRef = 4D1000073B00000000B1C2D3 /* Sparkle */; };
-		4D1000023B00000000B1C2D3 /* AppUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1000033B00000000B1C2D3 /* AppUpdater.swift */; };
-		4D3A00023C00000000E1F1A1 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3A00043C00000000E1F1A1 /* KeychainService.swift */; };
-		4D3A00053C00000000E1F1A1 /* Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3A00063C00000000E1F1A1 /* Host.swift */; };
-		4D4A00123D00000000E2F2A2 /* HostRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4A00113D00000000E2F2A2 /* HostRepository.swift */; };
-		4D5A00233E00000000F3F3A3 /* TorrentParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5A00223E00000000F3F3A3 /* TorrentParsing.swift */; };
-		4D5A00243E00000000F3F3A3 /* TorrentSorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5A00253E00000000F3F3A3 /* TorrentSorting.swift */; };
-		4D6A00213F00000000A1B2C3 /* TransmissionSessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6A00203F00000000A1B2C3 /* TransmissionSessionModels.swift */; };
-		4E1000043F00000000A1B2C4 /* macOSTorrentEdit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1000023F00000000A1B2C4 /* macOSTorrentEdit.swift */; };
-		4E2000014000000000C1D2E3 /* SpeedLimitsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2000044000000000C1D2E3 /* SpeedLimitsSettings.swift */; };
-		4E2000024000000000C1D2E3 /* NetworkSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2000054000000000C1D2E3 /* NetworkSettings.swift */; };
-		4E2000034000000000C1D2E3 /* TorrentSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2000064000000000C1D2E3 /* TorrentSettings.swift */; };
-		4E2000084000000000C1D2E3 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2000094000000000C1D2E3 /* SettingsViewModel.swift */; };
-		4F7000024000000000A1B2C3 /* iOSTorrentFileRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7000014000000000A1B2C3 /* iOSTorrentFileRow.swift */; };
-		4F7000044000000000A1B2C3 /* iOSTorrentFileDetailControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7000034000000000A1B2C3 /* iOSTorrentFileDetailControls.swift */; };
-		4F8000044000000000A1B2C3 /* macOSContentSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8000014000000000A1B2C3 /* macOSContentSidebar.swift */; };
-		4F8000054000000000A1B2C3 /* macOSContentDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8000024000000000A1B2C3 /* macOSContentDetail.swift */; };
-		4F8000064000000000A1B2C3 /* macOSContentToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8000034000000000A1B2C3 /* macOSContentToolbar.swift */; };
-		5A1000014100000000A1B2C3 /* TransmissionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1000064100000000A1B2C3 /* TransmissionModels.swift */; };
-		5A1000214100000000A1B2C3 /* TransmissionTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1000224100000000A1B2C3 /* TransmissionTransport.swift */; };
-		5A1000234100000000A1B2C3 /* TransmissionConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1000244100000000A1B2C3 /* TransmissionConnection.swift */; };
-		6A1000014200000000A1B2C3 /* TransmissionConnectionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1000024200000000A1B2C3 /* TransmissionConnectionFactory.swift */; };
-		6A1000034200000000A1B2C3 /* TransmissionTorrents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1000044200000000A1B2C3 /* TransmissionTorrents.swift */; };
-		6A1000054200000000A1B2C3 /* TransmissionSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1000064200000000A1B2C3 /* TransmissionSession.swift */; };
-		6A1000074200000000A1B2C3 /* TransmissionErrorPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1000084200000000A1B2C3 /* TransmissionErrorPresentation.swift */; };
-		7B1000014300000000A1B2C3 /* Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1000024300000000A1B2C3 /* Formatting.swift */; };
-		7B1000034300000000A1B2C3 /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1000044300000000A1B2C3 /* Sorting.swift */; };
-		7B1000054300000000A1B2C3 /* TransmissionReadSnapshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1000064300000000A1B2C3 /* TransmissionReadSnapshots.swift */; };
-		7B1000094300000000A1B2C3 /* TransmissionActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B10000A4300000000A1B2C3 /* TransmissionActions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -144,111 +47,15 @@
 
 /* Begin PBXFileReference section */
 		4B1DADDB295E6C440037E9FB /* BitDream.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BitDream.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		4B1DADDE295E6C440037E9FB /* BitDreamApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitDreamApp.swift; sourceTree = "<group>"; };
-		4B1DADE0295E6C440037E9FB /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
-		4B1DADE5295E6C440037E9FB /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		4B1DADE7295E6C450037E9FB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		4B1DADE9295E6C450037E9FB /* BitDream.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BitDream.entitlements; sourceTree = "<group>"; };
-		4B1DADEB295E6C450037E9FB /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		4B1DADFD295E6F390037E9FB /* TransmissionTorrentModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionTorrentModels.swift; sourceTree = "<group>"; };
-		4B1DAE01295E6FA30037E9FB /* AddTorrent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTorrent.swift; sourceTree = "<group>"; };
-		4B1DAE05295E6FC80037E9FB /* TorrentDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentDetail.swift; sourceTree = "<group>"; };
-		4B1DAE09295E6FE10037E9FB /* ServerDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerDetail.swift; sourceTree = "<group>"; };
-		4B1DAE0B295E6FEF0037E9FB /* ServerList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerList.swift; sourceTree = "<group>"; };
-		4B1DAE0D295E6FFB0037E9FB /* ErrorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDialog.swift; sourceTree = "<group>"; };
-		4B1DAE0F295E702B0037E9FB /* TransmissionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionStore.swift; sourceTree = "<group>"; };
-		4B4E4C182E8A1F6E00418FD7 /* BitDreamAppIconBlue.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = BitDreamAppIconBlue.icon; sourceTree = "<group>"; };
-		4B4E4C192E8A1F6E00418FD7 /* BitDreamAppIconDefault.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = BitDreamAppIconDefault.icon; sourceTree = "<group>"; };
-		4B4E4C892E8A2B4D00418FD7 /* AppIconCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCatalog.swift; sourceTree = "<group>"; };
-		4B61EA9C2E8A396D005BD750 /* BitDreamAppIconPinkBg.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = BitDreamAppIconPinkBg.icon; sourceTree = "<group>"; };
-		4B642D6A2D7E151A003CEADC /* iOSServerDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSServerDetail.swift; sourceTree = "<group>"; };
-		4B642D6B2D7E151A003CEADC /* macOSServerDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSServerDetail.swift; sourceTree = "<group>"; };
-		4B642D782D7E1EED003CEADC /* macOSServerList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSServerList.swift; sourceTree = "<group>"; };
-		4B642D7A2D7E1EF6003CEADC /* iOSServerList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSServerList.swift; sourceTree = "<group>"; };
-		4B6F1EA52D82BD4A003D8F6E /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		4B6F1EAD2D82D337003D8F6E /* macOSSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSSettingsView.swift; sourceTree = "<group>"; };
-		4B6F1EAF2D82D340003D8F6E /* iOSSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSSettingsView.swift; sourceTree = "<group>"; };
-		4B6F1EB12D82DB21003D8F6E /* TorrentListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentListRow.swift; sourceTree = "<group>"; };
-		4B6F1EB32D82DB2D003D8F6E /* iOSTorrentListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTorrentListRow.swift; sourceTree = "<group>"; };
-		4B6F1EBB2D86C908003D8F6E /* macOSTorrentFileDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSTorrentFileDetail.swift; sourceTree = "<group>"; };
-		4B6F1EBD2D86C926003D8F6E /* iOSTorrentFileDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTorrentFileDetail.swift; sourceTree = "<group>"; };
-		4B6F1EBF2D86D52A003D8F6E /* TorrentFileDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentFileDetail.swift; sourceTree = "<group>"; };
-		4B73985A2E70097C00D06E5D /* AppFileOpenDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFileOpenDelegate.swift; sourceTree = "<group>"; };
-		4B73985D2E70181D00D06E5D /* macOSStatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSStatisticsView.swift; sourceTree = "<group>"; };
-		4B73985F2E7029BD00D06E5D /* macOSAboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSAboutView.swift; sourceTree = "<group>"; };
-		4B73986B2F1A112200D06E5D /* macOSConnectionInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSConnectionInfoView.swift; sourceTree = "<group>"; };
-		4B7EF5702E6E9F0C00C1C281 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
-		4B908AED2E6EBAC700C2DA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		4B9CAC532D7E833A0094CD03 /* macOSAddTorrent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSAddTorrent.swift; sourceTree = "<group>"; };
-		4B9CAC552D7E83460094CD03 /* iOSAddTorrent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSAddTorrent.swift; sourceTree = "<group>"; };
-		4BC2C9272E6E22B800011971 /* macOSTorrentList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSTorrentList.swift; sourceTree = "<group>"; };
-		4BC2C9282E6E22B800011971 /* macOSTorrentListCompact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSTorrentListCompact.swift; sourceTree = "<group>"; };
-		4BC2C9292E6E22B800011971 /* macOSTorrentListExpanded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSTorrentListExpanded.swift; sourceTree = "<group>"; };
-		4BC4A4B92E7248A300578D08 /* macOSMenuCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSMenuCommands.swift; sourceTree = "<group>"; };
-		4BC5C2A72D7D20B500D80AB4 /* iOSContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSContentView.swift; sourceTree = "<group>"; };
-		4BC5C2A82D7D20B500D80AB4 /* macOSContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSContentView.swift; sourceTree = "<group>"; };
-		4BC5C2B12D7D415100D80AB4 /* iOSTorrentDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTorrentDetail.swift; sourceTree = "<group>"; };
-		4BC5C2B22D7D415100D80AB4 /* macOSTorrentDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSTorrentDetail.swift; sourceTree = "<group>"; };
-		4BC6F24A2E89F8510037DFDF /* PiecesGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiecesGridView.swift; sourceTree = "<group>"; };
-		4BCF274D2E774EDC00F6BF76 /* DataModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataModels.swift; sourceTree = "<group>"; };
-		4BCF274E2E774EDC00F6BF76 /* DataWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataWriter.swift; sourceTree = "<group>"; };
-		4BD855492E77424B00606224 /* WidgetKitBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetKitBridge.swift; sourceTree = "<group>"; };
-		4BD938E92D82AF6F006CE97C /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
-		4BDA6AA82E8AD06D009E6098 /* BitDreamAppIconPixelyClouds.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = BitDreamAppIconPixelyClouds.icon; sourceTree = "<group>"; };
+		4BCF274D2E774EDC00F6BF76 /* BitDream/Widgets/DataModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitDream/Widgets/DataModels.swift; sourceTree = SOURCE_ROOT; };
+		4BD855492E77424B00606224 /* BitDream/Widgets/WidgetKitBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitDream/Widgets/WidgetKitBridge.swift; sourceTree = SOURCE_ROOT; };
 		4BDACD142E73DB220074F714 /* BitDreamWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BitDreamWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BDACD162E73DB220074F714 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		4BDACD182E73DB220074F714 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
-		4BDACD502E73DBBE0074F714 /* AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroup.swift; sourceTree = "<group>"; };
-		4BDE147E2F0B015C00FF6A46 /* AppIconManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconManager.swift; sourceTree = "<group>"; };
-		4BE364B92E6E75B300CF1A33 /* SharedComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedComponents.swift; sourceTree = "<group>"; };
-		4BEFEE7B2E6E5E69005815FA /* ContentTypeIconMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTypeIconMapper.swift; sourceTree = "<group>"; };
-		4BF593B62E89BF5500A8C1FC /* macOSTorrentPeerDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSTorrentPeerDetail.swift; sourceTree = "<group>"; };
-		4BF593B82E89BF6300A8C1FC /* TorrentPeerDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentPeerDetail.swift; sourceTree = "<group>"; };
-		4BF593BA2E89C8C400A8C1FC /* iOSTorrentPeerDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTorrentPeerDetail.swift; sourceTree = "<group>"; };
-		4BFFAA002E7F000000000001 /* macOSTorrentActionsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSTorrentActionsMenu.swift; sourceTree = "<group>"; };
-		4C1000013A00000000A1B2C3 /* MenuBarTorrentSelectors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarTorrentSelectors.swift; sourceTree = "<group>"; };
-		4C1000023A00000000A1B2C3 /* macOSMenuBarTorrentRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSMenuBarTorrentRow.swift; sourceTree = "<group>"; };
-		4C1000033A00000000A1B2C3 /* macOSMenuBarTorrentWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSMenuBarTorrentWidget.swift; sourceTree = "<group>"; };
-		4C1000043A00000000A1B2C3 /* ConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatus.swift; sourceTree = "<group>"; };
-		4C1000053A00000000A1B2C3 /* MenuBarStatusItemBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusItemBridge.swift; sourceTree = "<group>"; };
-		4C2000013C00000000A1B2C3 /* macOSGeneralSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSGeneralSettingsTab.swift; sourceTree = "<group>"; };
-		4C2000023C00000000A1B2C3 /* macOSTorrentSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSTorrentSettingsTab.swift; sourceTree = "<group>"; };
-		4C2000033C00000000A1B2C3 /* macOSSpeedLimitsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSSpeedLimitsSettingsTab.swift; sourceTree = "<group>"; };
-		4C2000043C00000000A1B2C3 /* macOSNetworkSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSNetworkSettingsTab.swift; sourceTree = "<group>"; };
-		4C3000033C10000000A1B2C3 /* iOSTorrentsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTorrentsSettingsView.swift; sourceTree = "<group>"; };
-		4C3000043C10000000A1B2C3 /* iOSSpeedLimitsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSSpeedLimitsSettingsView.swift; sourceTree = "<group>"; };
-		4C3000053C10000000A1B2C3 /* iOSNetworkSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSNetworkSettingsView.swift; sourceTree = "<group>"; };
-		4D1000033B00000000B1C2D3 /* AppUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdater.swift; sourceTree = "<group>"; };
+		4BDACD502E73DBBE0074F714 /* BitDream/Widgets/AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitDream/Widgets/AppGroup.swift; sourceTree = SOURCE_ROOT; };
 		4D2000013B10000000C3D4E5 /* BuildSettings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BuildSettings.xcconfig; sourceTree = "<group>"; };
 		4D2000023B10000000C3D4E5 /* BuildSettings.example.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BuildSettings.example.local.xcconfig; sourceTree = "<group>"; };
-		4D3A00043C00000000E1F1A1 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
-		4D3A00063C00000000E1F1A1 /* Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
-		4D4A00113D00000000E2F2A2 /* HostRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostRepository.swift; sourceTree = "<group>"; };
-		4D5A00223E00000000F3F3A3 /* TorrentParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentParsing.swift; sourceTree = "<group>"; };
-		4D5A00253E00000000F3F3A3 /* TorrentSorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentSorting.swift; sourceTree = "<group>"; };
-		4D6A00203F00000000A1B2C3 /* TransmissionSessionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionSessionModels.swift; sourceTree = "<group>"; };
-		4E1000023F00000000A1B2C4 /* macOSTorrentEdit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSTorrentEdit.swift; sourceTree = "<group>"; };
-		4E2000044000000000C1D2E3 /* SpeedLimitsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedLimitsSettings.swift; sourceTree = "<group>"; };
-		4E2000054000000000C1D2E3 /* NetworkSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSettings.swift; sourceTree = "<group>"; };
-		4E2000064000000000C1D2E3 /* TorrentSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentSettings.swift; sourceTree = "<group>"; };
-		4E2000094000000000C1D2E3 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
-		4F7000014000000000A1B2C3 /* iOSTorrentFileRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTorrentFileRow.swift; sourceTree = "<group>"; };
-		4F7000034000000000A1B2C3 /* iOSTorrentFileDetailControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTorrentFileDetailControls.swift; sourceTree = "<group>"; };
-		4F8000014000000000A1B2C3 /* macOSContentSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSContentSidebar.swift; sourceTree = "<group>"; };
-		4F8000024000000000A1B2C3 /* macOSContentDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSContentDetail.swift; sourceTree = "<group>"; };
-		4F8000034000000000A1B2C3 /* macOSContentToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSContentToolbar.swift; sourceTree = "<group>"; };
-		5A1000064100000000A1B2C3 /* TransmissionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionModels.swift; sourceTree = "<group>"; };
 		5A1000074100000000A1B2C3 /* BitDreamTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BitDreamTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		5A1000224100000000A1B2C3 /* TransmissionTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionTransport.swift; sourceTree = "<group>"; };
-		5A1000244100000000A1B2C3 /* TransmissionConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionConnection.swift; sourceTree = "<group>"; };
-		6A1000024200000000A1B2C3 /* TransmissionConnectionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionConnectionFactory.swift; sourceTree = "<group>"; };
-		6A1000044200000000A1B2C3 /* TransmissionTorrents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionTorrents.swift; sourceTree = "<group>"; };
-		6A1000064200000000A1B2C3 /* TransmissionSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionSession.swift; sourceTree = "<group>"; };
-		6A1000084200000000A1B2C3 /* TransmissionErrorPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionErrorPresentation.swift; sourceTree = "<group>"; };
-		7B1000024300000000A1B2C3 /* Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatting.swift; sourceTree = "<group>"; };
-		7B1000044300000000A1B2C3 /* Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sorting.swift; sourceTree = "<group>"; };
-		7B1000064300000000A1B2C3 /* TransmissionReadSnapshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionReadSnapshots.swift; sourceTree = "<group>"; };
-		7B10000A4300000000A1B2C3 /* TransmissionActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionActions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -259,12 +66,32 @@
 			);
 			target = 4BDACD132E73DB220074F714 /* BitDreamWidgetsExtension */;
 		};
+		4C9C00013F10000000B1C2D3 /* Exceptions for "BitDream" folder in "BitDream" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+				"Transmission/TransmissionRPC/Examples/session-get.response.json",
+				"Transmission/TransmissionRPC/Examples/session-stats.response.json",
+				"Transmission/TransmissionRPC/Examples/torrent-get.response.json",
+				"Transmission/TransmissionRPC/Transmission-RPC-Spec.md",
+				Widgets/README.md,
+			);
+			target = 4B1DADDA295E6C440037E9FB /* BitDream */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		4BCF27582E7751D400F6BF76 /* BackgroundRefresh */ = {
+		4B1DADDD295E6C440037E9FB /* BitDream */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			path = BackgroundRefresh;
+			exceptions = (
+				4C9C00013F10000000B1C2D3 /* Exceptions for "BitDream" folder in "BitDream" target */,
+			);
+			path = BitDream;
+			sourceTree = "<group>";
+		};
+		4B4E4C1A2E8A1F6E00418FD7 /* AppIcons */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = AppIcons;
 			sourceTree = "<group>";
 		};
 		4BDACD1A2E73DB220074F714 /* BitDreamWidgets */ = {
@@ -304,15 +131,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		4B0349D52F56EB81008ED58D /* AppIcon */ = {
-			isa = PBXGroup;
-			children = (
-				4B4E4C892E8A2B4D00418FD7 /* AppIconCatalog.swift */,
-				4BDE147E2F0B015C00FF6A46 /* AppIconManager.swift */,
-			);
-			path = AppIcon;
-			sourceTree = "<group>";
-		};
 		4B1DADD2295E6C440037E9FB = {
 			isa = PBXGroup;
 			children = (
@@ -323,6 +141,7 @@
 				4BDACD1A2E73DB220074F714 /* BitDreamWidgets */,
 				4BDACD152E73DB220074F714 /* Frameworks */,
 				4B1DADDC295E6C440037E9FB /* Products */,
+				4B2085FD2F5E628A005D6F26 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -336,153 +155,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		4B1DADDD295E6C440037E9FB /* BitDream */ = {
+		4B2085FD2F5E628A005D6F26 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
-				4B908AED2E6EBAC700C2DA5C /* Info.plist */,
-				4B7EF5702E6E9F0C00C1C281 /* AppConfig.swift */,
-				4D1000033B00000000B1C2D3 /* AppUpdater.swift */,
-				4B1DADDE295E6C440037E9FB /* BitDreamApp.swift */,
-				7B1000024300000000A1B2C3 /* Formatting.swift */,
-				4D3A00043C00000000E1F1A1 /* KeychainService.swift */,
-				7B1000044300000000A1B2C3 /* Sorting.swift */,
-				4BD938E92D82AF6F006CE97C /* ThemeManager.swift */,
-				4B1DAE0F295E702B0037E9FB /* TransmissionStore.swift */,
-				4B0349D52F56EB81008ED58D /* AppIcon */,
-				4B73985B2E70097C00D06E5D /* Delegates */,
-				4D3A00073C00000000E1F1A1 /* Models */,
-				4D4A00103D00000000E2F2A2 /* Persistence */,
-				4D5A00213E00000000F3F3A3 /* Torrent */,
-				4B1DADFC295E6F0F0037E9FB /* Transmission */,
-				4BDACD532E73DBBE0074F714 /* Widgets */,
-				4B1DADFA295E6EE10037E9FB /* Views */,
-				4B1DADE7295E6C450037E9FB /* Assets.xcassets */,
-				4B1DADE9295E6C450037E9FB /* BitDream.entitlements */,
-				4B1DADEA295E6C450037E9FB /* Preview Content */,
+				4BDACD502E73DBBE0074F714 /* BitDream/Widgets/AppGroup.swift */,
+				4BD855492E77424B00606224 /* BitDream/Widgets/WidgetKitBridge.swift */,
+				4BCF274D2E774EDC00F6BF76 /* BitDream/Widgets/DataModels.swift */,
 			);
-			path = BitDream;
-			sourceTree = "<group>";
-		};
-		4B1DADEA295E6C450037E9FB /* Preview Content */ = {
-			isa = PBXGroup;
-			children = (
-				4B1DADEB295E6C450037E9FB /* Preview Assets.xcassets */,
-			);
-			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		4B1DADFA295E6EE10037E9FB /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				4B642D772D7E1D6B003CEADC /* Shared */,
-				4B642D762D7E1D60003CEADC /* macOS */,
-				4B642D752D7E1D4C003CEADC /* iOS */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
-		4B1DADFC295E6F0F0037E9FB /* Transmission */ = {
-			isa = PBXGroup;
-			children = (
-				5A1000064100000000A1B2C3 /* TransmissionModels.swift */,
-				5A1000224100000000A1B2C3 /* TransmissionTransport.swift */,
-				5A1000244100000000A1B2C3 /* TransmissionConnection.swift */,
-				6A1000024200000000A1B2C3 /* TransmissionConnectionFactory.swift */,
-				7B1000064300000000A1B2C3 /* TransmissionReadSnapshots.swift */,
-				6A1000044200000000A1B2C3 /* TransmissionTorrents.swift */,
-				6A1000064200000000A1B2C3 /* TransmissionSession.swift */,
-				6A1000084200000000A1B2C3 /* TransmissionErrorPresentation.swift */,
-				4D6A00203F00000000A1B2C3 /* TransmissionSessionModels.swift */,
-				4B1DADFD295E6F390037E9FB /* TransmissionTorrentModels.swift */,
-			);
-			path = Transmission;
-			sourceTree = "<group>";
-		};
-		4B4E4C1A2E8A1F6E00418FD7 /* AppIcons */ = {
-			isa = PBXGroup;
-			children = (
-				4B4E4C192E8A1F6E00418FD7 /* BitDreamAppIconDefault.icon */,
-				4B4E4C182E8A1F6E00418FD7 /* BitDreamAppIconBlue.icon */,
-				4B61EA9C2E8A396D005BD750 /* BitDreamAppIconPinkBg.icon */,
-				4BDA6AA82E8AD06D009E6098 /* BitDreamAppIconPixelyClouds.icon */,
-			);
-			path = AppIcons;
-			sourceTree = "<group>";
-		};
-		4B642D752D7E1D4C003CEADC /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				4C3000013C10000000A1B2C3 /* Settings */,
-				4B9CAC552D7E83460094CD03 /* iOSAddTorrent.swift */,
-				4BC5C2A72D7D20B500D80AB4 /* iOSContentView.swift */,
-				4B642D6A2D7E151A003CEADC /* iOSServerDetail.swift */,
-				4B642D7A2D7E1EF6003CEADC /* iOSServerList.swift */,
-				4BC5C2B12D7D415100D80AB4 /* iOSTorrentDetail.swift */,
-				4B6F1EBD2D86C926003D8F6E /* iOSTorrentFileDetail.swift */,
-				4F7000034000000000A1B2C3 /* iOSTorrentFileDetailControls.swift */,
-				4F7000014000000000A1B2C3 /* iOSTorrentFileRow.swift */,
-				4B6F1EB32D82DB2D003D8F6E /* iOSTorrentListRow.swift */,
-				4BF593BA2E89C8C400A8C1FC /* iOSTorrentPeerDetail.swift */,
-			);
-			path = iOS;
-			sourceTree = "<group>";
-		};
-		4B642D762D7E1D60003CEADC /* macOS */ = {
-			isa = PBXGroup;
-			children = (
-				4C1000003A00000000A1B2C3 /* MenuBar */,
-				4C2000003C00000000A1B2C3 /* Settings */,
-				4B73985F2E7029BD00D06E5D /* macOSAboutView.swift */,
-				4B9CAC532D7E833A0094CD03 /* macOSAddTorrent.swift */,
-				4B73986B2F1A112200D06E5D /* macOSConnectionInfoView.swift */,
-				4F8000024000000000A1B2C3 /* macOSContentDetail.swift */,
-				4F8000014000000000A1B2C3 /* macOSContentSidebar.swift */,
-				4F8000034000000000A1B2C3 /* macOSContentToolbar.swift */,
-				4BC5C2A82D7D20B500D80AB4 /* macOSContentView.swift */,
-				4BC4A4B92E7248A300578D08 /* macOSMenuCommands.swift */,
-				4B642D6B2D7E151A003CEADC /* macOSServerDetail.swift */,
-				4B642D782D7E1EED003CEADC /* macOSServerList.swift */,
-				4B73985D2E70181D00D06E5D /* macOSStatisticsView.swift */,
-				4BFFAA002E7F000000000001 /* macOSTorrentActionsMenu.swift */,
-				4BC5C2B22D7D415100D80AB4 /* macOSTorrentDetail.swift */,
-				4E1000023F00000000A1B2C4 /* macOSTorrentEdit.swift */,
-				4B6F1EBB2D86C908003D8F6E /* macOSTorrentFileDetail.swift */,
-				4BC2C9272E6E22B800011971 /* macOSTorrentList.swift */,
-				4BC2C9282E6E22B800011971 /* macOSTorrentListCompact.swift */,
-				4BC2C9292E6E22B800011971 /* macOSTorrentListExpanded.swift */,
-				4BF593B62E89BF5500A8C1FC /* macOSTorrentPeerDetail.swift */,
-			);
-			path = macOS;
-			sourceTree = "<group>";
-		};
-		4B642D772D7E1D6B003CEADC /* Shared */ = {
-			isa = PBXGroup;
-			children = (
-				4E2000074000000000C1D2E3 /* Settings */,
-				4B1DAE01295E6FA30037E9FB /* AddTorrent.swift */,
-				4C1000043A00000000A1B2C3 /* ConnectionStatus.swift */,
-				4BEFEE7B2E6E5E69005815FA /* ContentTypeIconMapper.swift */,
-				4B1DADE5295E6C440037E9FB /* ContentView.swift */,
-				4B1DAE0D295E6FFB0037E9FB /* ErrorDialog.swift */,
-				4BC6F24A2E89F8510037DFDF /* PiecesGridView.swift */,
-				4BE364B92E6E75B300CF1A33 /* SharedComponents.swift */,
-				4B1DAE09295E6FE10037E9FB /* ServerDetail.swift */,
-				4B1DAE0B295E6FEF0037E9FB /* ServerList.swift */,
-				4B1DAE05295E6FC80037E9FB /* TorrentDetail.swift */,
-				7B10000A4300000000A1B2C3 /* TransmissionActions.swift */,
-				4B6F1EBF2D86D52A003D8F6E /* TorrentFileDetail.swift */,
-				4B6F1EB12D82DB21003D8F6E /* TorrentListRow.swift */,
-				4BF593B82E89BF6300A8C1FC /* TorrentPeerDetail.swift */,
-			);
-			path = Shared;
-			sourceTree = "<group>";
-		};
-		4B73985B2E70097C00D06E5D /* Delegates */ = {
-			isa = PBXGroup;
-			children = (
-				4B73985A2E70097C00D06E5D /* AppFileOpenDelegate.swift */,
-			);
-			path = Delegates;
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		4BDACD152E73DB220074F714 /* Frameworks */ = {
@@ -494,52 +174,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		4BDACD532E73DBBE0074F714 /* Widgets */ = {
-			isa = PBXGroup;
-			children = (
-				4BCF27582E7751D400F6BF76 /* BackgroundRefresh */,
-				4BDACD502E73DBBE0074F714 /* AppGroup.swift */,
-				4BCF274D2E774EDC00F6BF76 /* DataModels.swift */,
-				4BCF274E2E774EDC00F6BF76 /* DataWriter.swift */,
-				4BD855492E77424B00606224 /* WidgetKitBridge.swift */,
-			);
-			path = Widgets;
-			sourceTree = "<group>";
-		};
-		4C1000003A00000000A1B2C3 /* MenuBar */ = {
-			isa = PBXGroup;
-			children = (
-				4C1000023A00000000A1B2C3 /* macOSMenuBarTorrentRow.swift */,
-				4C1000033A00000000A1B2C3 /* macOSMenuBarTorrentWidget.swift */,
-				4C1000053A00000000A1B2C3 /* MenuBarStatusItemBridge.swift */,
-				4C1000013A00000000A1B2C3 /* MenuBarTorrentSelectors.swift */,
-			);
-			path = MenuBar;
-			sourceTree = "<group>";
-		};
-		4C2000003C00000000A1B2C3 /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				4B6F1EAD2D82D337003D8F6E /* macOSSettingsView.swift */,
-				4C2000013C00000000A1B2C3 /* macOSGeneralSettingsTab.swift */,
-				4C2000043C00000000A1B2C3 /* macOSNetworkSettingsTab.swift */,
-				4C2000033C00000000A1B2C3 /* macOSSpeedLimitsSettingsTab.swift */,
-				4C2000023C00000000A1B2C3 /* macOSTorrentSettingsTab.swift */,
-			);
-			path = Settings;
-			sourceTree = "<group>";
-		};
-		4C3000013C10000000A1B2C3 /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				4B6F1EAF2D82D340003D8F6E /* iOSSettingsView.swift */,
-				4C3000053C10000000A1B2C3 /* iOSNetworkSettingsView.swift */,
-				4C3000043C10000000A1B2C3 /* iOSSpeedLimitsSettingsView.swift */,
-				4C3000033C10000000A1B2C3 /* iOSTorrentsSettingsView.swift */,
-			);
-			path = Settings;
-			sourceTree = "<group>";
-		};
 		4D2000033B10000000C3D4E5 /* Config */ = {
 			isa = PBXGroup;
 			children = (
@@ -547,44 +181,6 @@
 				4D2000023B10000000C3D4E5 /* BuildSettings.example.local.xcconfig */,
 			);
 			path = Config;
-			sourceTree = "<group>";
-		};
-		4D3A00073C00000000E1F1A1 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				4D3A00063C00000000E1F1A1 /* Host.swift */,
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
-		4D4A00103D00000000E2F2A2 /* Persistence */ = {
-			isa = PBXGroup;
-			children = (
-				4B1DADE0295E6C440037E9FB /* PersistenceController.swift */,
-				4D4A00113D00000000E2F2A2 /* HostRepository.swift */,
-			);
-			path = Persistence;
-			sourceTree = "<group>";
-		};
-		4D5A00213E00000000F3F3A3 /* Torrent */ = {
-			isa = PBXGroup;
-			children = (
-				4D5A00253E00000000F3F3A3 /* TorrentSorting.swift */,
-				4D5A00223E00000000F3F3A3 /* TorrentParsing.swift */,
-			);
-			path = Torrent;
-			sourceTree = "<group>";
-		};
-		4E2000074000000000C1D2E3 /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				4B6F1EA52D82BD4A003D8F6E /* SettingsView.swift */,
-				4E2000094000000000C1D2E3 /* SettingsViewModel.swift */,
-				4E2000054000000000C1D2E3 /* NetworkSettings.swift */,
-				4E2000044000000000C1D2E3 /* SpeedLimitsSettings.swift */,
-				4E2000064000000000C1D2E3 /* TorrentSettings.swift */,
-			);
-			path = Settings;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -605,7 +201,8 @@
 				4BDACD292E73DB230074F714 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				4BCF27582E7751D400F6BF76 /* BackgroundRefresh */,
+				4B1DADDD295E6C440037E9FB /* BitDream */,
+				4B4E4C1A2E8A1F6E00418FD7 /* AppIcons */,
 			);
 			name = BitDream;
 			packageProductDependencies = (
@@ -703,12 +300,6 @@
 		4B1DADD9295E6C440037E9FB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			files = (
-				4B61EA9D2E8A396D005BD750 /* BitDreamAppIconPinkBg.icon in Resources */,
-				4B4E4C1B2E8A1F6E00418FD7 /* BitDreamAppIconBlue.icon in Resources */,
-				4B4E4C1C2E8A1F6E00418FD7 /* BitDreamAppIconDefault.icon in Resources */,
-				4B1DADEC295E6C450037E9FB /* Preview Assets.xcassets in Resources */,
-				4B1DADE8295E6C450037E9FB /* Assets.xcassets in Resources */,
-				4BDA6AA92E8AD06D009E6098 /* BitDreamAppIconPixelyClouds.icon in Resources */,
 			);
 		};
 		4BDACD122E73DB220074F714 /* Resources */ = {
@@ -727,105 +318,14 @@
 		4B1DADD7295E6C440037E9FB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
-				4BC4A4BA2E7248A300578D08 /* macOSMenuCommands.swift in Sources */,
-				4B7EF5712E6E9F0C00C1C281 /* AppConfig.swift in Sources */,
-				4B1DADDF295E6C440037E9FB /* BitDreamApp.swift in Sources */,
-				4D1000023B00000000B1C2D3 /* AppUpdater.swift in Sources */,
-				4D3A00053C00000000E1F1A1 /* Host.swift in Sources */,
-				4B1DADE1295E6C440037E9FB /* PersistenceController.swift in Sources */,
-				4D4A00123D00000000E2F2A2 /* HostRepository.swift in Sources */,
-				4B1DAE10295E702B0037E9FB /* TransmissionStore.swift in Sources */,
-				4B4E4C8A2E8A2B4D00418FD7 /* AppIconCatalog.swift in Sources */,
-				4BF593BB2E89C8C400A8C1FC /* iOSTorrentPeerDetail.swift in Sources */,
-				4D5A00233E00000000F3F3A3 /* TorrentParsing.swift in Sources */,
-				4D5A00243E00000000F3F3A3 /* TorrentSorting.swift in Sources */,
-				7B1000014300000000A1B2C3 /* Formatting.swift in Sources */,
-				7B1000034300000000A1B2C3 /* Sorting.swift in Sources */,
-				4D3A00023C00000000E1F1A1 /* KeychainService.swift in Sources */,
-				4B6F1EB02D82D340003D8F6E /* iOSSettingsView.swift in Sources */,
-				4BC6F24B2E89F8510037DFDF /* PiecesGridView.swift in Sources */,
-				4B6F1EBC2D86C908003D8F6E /* macOSTorrentFileDetail.swift in Sources */,
-				5A1000014100000000A1B2C3 /* TransmissionModels.swift in Sources */,
-				5A1000214100000000A1B2C3 /* TransmissionTransport.swift in Sources */,
-				5A1000234100000000A1B2C3 /* TransmissionConnection.swift in Sources */,
-				7B1000054300000000A1B2C3 /* TransmissionReadSnapshots.swift in Sources */,
-				6A1000014200000000A1B2C3 /* TransmissionConnectionFactory.swift in Sources */,
-				6A1000034200000000A1B2C3 /* TransmissionTorrents.swift in Sources */,
-				6A1000054200000000A1B2C3 /* TransmissionSession.swift in Sources */,
-				6A1000074200000000A1B2C3 /* TransmissionErrorPresentation.swift in Sources */,
-				4BDE147F2F0B015C00FF6A46 /* AppIconManager.swift in Sources */,
-				4BD938EB2D82AF6F006CE97C /* ThemeManager.swift in Sources */,
-				4B1DADFE295E6F390037E9FB /* TransmissionTorrentModels.swift in Sources */,
-				4D6A00213F00000000A1B2C3 /* TransmissionSessionModels.swift in Sources */,
-				4B1DAE02295E6FA30037E9FB /* AddTorrent.swift in Sources */,
-				4C1000143A00000000A1B2C3 /* ConnectionStatus.swift in Sources */,
-				4B1DADE6295E6C440037E9FB /* ContentView.swift in Sources */,
-				4B1DAE0E295E6FFB0037E9FB /* ErrorDialog.swift in Sources */,
-				4B1DAE0A295E6FE10037E9FB /* ServerDetail.swift in Sources */,
-				4B6F1EA62D82BD4A003D8F6E /* SettingsView.swift in Sources */,
-				4E2000084000000000C1D2E3 /* SettingsViewModel.swift in Sources */,
-				4B1DAE0C295E6FEF0037E9FB /* ServerList.swift in Sources */,
-				4E2000024000000000C1D2E3 /* NetworkSettings.swift in Sources */,
-				4E2000014000000000C1D2E3 /* SpeedLimitsSettings.swift in Sources */,
-				4B6F1EB22D82DB21003D8F6E /* TorrentListRow.swift in Sources */,
-				4B1DAE06295E6FC80037E9FB /* TorrentDetail.swift in Sources */,
-				4E2000034000000000C1D2E3 /* TorrentSettings.swift in Sources */,
-				4B6F1EBE2D86C926003D8F6E /* iOSTorrentFileDetail.swift in Sources */,
-				4F7000044000000000A1B2C3 /* iOSTorrentFileDetailControls.swift in Sources */,
-				4F7000024000000000A1B2C3 /* iOSTorrentFileRow.swift in Sources */,
-				4B73985C2E70097C00D06E5D /* AppFileOpenDelegate.swift in Sources */,
-				4BCF274F2E774EDC00F6BF76 /* DataWriter.swift in Sources */,
-				4BCF27502E774EDC00F6BF76 /* DataModels.swift in Sources */,
-				4B9CAC562D7E83460094CD03 /* iOSAddTorrent.swift in Sources */,
-				4BE364BA2E6E75B300CF1A33 /* SharedComponents.swift in Sources */,
-				7B1000094300000000A1B2C3 /* TransmissionActions.swift in Sources */,
-				4BF593B72E89BF5500A8C1FC /* macOSTorrentPeerDetail.swift in Sources */,
-				4BF593B92E89BF6300A8C1FC /* TorrentPeerDetail.swift in Sources */,
-				4BC5C2AA2D7D20B500D80AB4 /* iOSContentView.swift in Sources */,
-				4B642D6D2D7E151A003CEADC /* iOSServerDetail.swift in Sources */,
-				4BDACD572E73DBBE0074F714 /* AppGroup.swift in Sources */,
-				4B7398602E7029BD00D06E5D /* macOSAboutView.swift in Sources */,
-				4B642D7B2D7E1EF6003CEADC /* iOSServerList.swift in Sources */,
-				4C3000093C10000000A1B2C3 /* iOSNetworkSettingsView.swift in Sources */,
-				4C3000083C10000000A1B2C3 /* iOSSpeedLimitsSettingsView.swift in Sources */,
-				4C3000073C10000000A1B2C3 /* iOSTorrentsSettingsView.swift in Sources */,
-				4B6F1EC02D86D52A003D8F6E /* TorrentFileDetail.swift in Sources */,
-				4BC2C92A2E6E22B800011971 /* macOSTorrentList.swift in Sources */,
-				4BC2C92B2E6E22B800011971 /* macOSTorrentListExpanded.swift in Sources */,
-				4BC2C92C2E6E22B800011971 /* macOSTorrentListCompact.swift in Sources */,
-				4BC5C2B42D7D415100D80AB4 /* iOSTorrentDetail.swift in Sources */,
-				4B9CAC542D7E833A0094CD03 /* macOSAddTorrent.swift in Sources */,
-				4C2000053C00000000A1B2C3 /* macOSGeneralSettingsTab.swift in Sources */,
-				4C2000083C00000000A1B2C3 /* macOSNetworkSettingsTab.swift in Sources */,
-				4B6F1EAE2D82D337003D8F6E /* macOSSettingsView.swift in Sources */,
-				4C2000073C00000000A1B2C3 /* macOSSpeedLimitsSettingsTab.swift in Sources */,
-				4C2000063C00000000A1B2C3 /* macOSTorrentSettingsTab.swift in Sources */,
-				4BD8554B2E77424B00606224 /* WidgetKitBridge.swift in Sources */,
-				4F8000054000000000A1B2C3 /* macOSContentDetail.swift in Sources */,
-				4F8000044000000000A1B2C3 /* macOSContentSidebar.swift in Sources */,
-				4F8000064000000000A1B2C3 /* macOSContentToolbar.swift in Sources */,
-				4BC5C2AC2D7D20B500D80AB4 /* macOSContentView.swift in Sources */,
-				4B73985E2E70181D00D06E5D /* macOSStatisticsView.swift in Sources */,
-				4B73986C2F1A112200D06E5D /* macOSConnectionInfoView.swift in Sources */,
-				4B642D6C2D7E151A003CEADC /* macOSServerDetail.swift in Sources */,
-				4B642D792D7E1EED003CEADC /* macOSServerList.swift in Sources */,
-				4BC5C2B32D7D415100D80AB4 /* macOSTorrentDetail.swift in Sources */,
-				4C1000113A00000000A1B2C3 /* MenuBarTorrentSelectors.swift in Sources */,
-				4C1000123A00000000A1B2C3 /* macOSMenuBarTorrentRow.swift in Sources */,
-				4C1000133A00000000A1B2C3 /* macOSMenuBarTorrentWidget.swift in Sources */,
-				4C1000153A00000000A1B2C3 /* MenuBarStatusItemBridge.swift in Sources */,
-				4B6F1EB42D82DB2D003D8F6E /* iOSTorrentListRow.swift in Sources */,
-				4BEFEE7C2E6E5E69005815FA /* ContentTypeIconMapper.swift in Sources */,
-				4BFFAA012E7F000000000001 /* macOSTorrentActionsMenu.swift in Sources */,
-				4E1000043F00000000A1B2C4 /* macOSTorrentEdit.swift in Sources */,
 			);
 		};
 		4BDACD102E73DB220074F714 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
-				4B8670062E73DE6E0004ECBA /* AppGroup.swift in Sources */,
-				4BD8554A2E77424B00606224 /* WidgetKitBridge.swift in Sources */,
-				4BCF27512E774F3E00F6BF76 /* DataModels.swift in Sources */,
+				4B8670062E73DE6E0004ECBA /* BitDream/Widgets/AppGroup.swift in Sources */,
+				4BD8554A2E77424B00606224 /* BitDream/Widgets/WidgetKitBridge.swift in Sources */,
+				4BCF27512E774F3E00F6BF76 /* BitDream/Widgets/DataModels.swift in Sources */,
 			);
 		};
 		5A10000E4100000000A1B2C3 /* Sources */ = {


### PR DESCRIPTION
## Summary
Migrate the main `BitDream` app target from manually managed Xcode file membership to file-system-synchronized groups.

## What Changed
- converted the `BitDream` and `AppIcons` app target roots to synchronized groups
- removed manual app target source and resource membership entries from `project.pbxproj`
- kept widget extension shared files explicitly referenced via `SOURCE_ROOT`
- added app-target synchronized group exceptions for `Info.plist` and known non-product files
- removed the now-redundant standalone `BackgroundRefresh` synchronized root from the app target