### PR TITLE
Add iOS About screen

### DIFF
--- a/AppIcons/BitDreamAppIconDefault.icon/icon.json
+++ b/AppIcons/BitDreamAppIconDefault.icon/icon.json
@@ -1,7 +1,17 @@
 {
-  "fill" : {
-    "automatic-gradient" : "display-p3:0.80815,0.90184,0.95295,1.00000"
-  },
+  "fill-specializations" : [
+    {
+      "value" : {
+        "automatic-gradient" : "display-p3:0.80815,0.90184,0.95295,1.00000"
+      }
+    },
+    {
+      "appearance" : "dark",
+      "value" : {
+        "automatic-gradient" : "display-p3:0.11591,0.26375,0.42559,1.00000"
+      }
+    }
+  ],
   "groups" : [
     {
       "layers" : [

--- a/BitDream/Views/iOS/Settings/iOSAboutView.swift
+++ b/BitDream/Views/iOS/Settings/iOSAboutView.swift
@@ -1,0 +1,100 @@
+#if os(iOS)
+import SwiftUI
+
+struct iOSAboutView: View {
+    @EnvironmentObject var themeManager: ThemeManager
+    @Environment(\.openURL) var openURL
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    }
+
+    private var copyrightYear: String {
+        String(Calendar.current.component(.year, from: Date()))
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            // App Icon
+            Image("AppIconPreview-Default")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 100, height: 100)
+                .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+                .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 6)
+
+            // App Name and Tagline
+            VStack(spacing: 4) {
+                Text("BitDream")
+                    .font(.system(size: 24, weight: .bold, design: .monospaced))
+                    .foregroundStyle(.primary)
+
+                Text("Remote Control for Transmission")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            // Description
+            Text("BitDream is a native and feature-rich remote control client for Transmission web server. It provides a modern interface to manage your Transmission server from anywhere.")
+                .font(.system(size: 14))
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 24)
+
+            // Version Information
+            VStack(spacing: 2) {
+                HStack(spacing: 8) {
+                    Text("Version")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.secondary)
+                    Text(appVersion)
+                        .font(.system(size: 14, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.primary)
+                }
+
+                // Copyright
+                Text("© \(copyrightYear) Austin Smith")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.tertiary)
+                    .padding(.top, 12)
+            }
+
+            // Transmission Acknowledgment
+            VStack(spacing: 8) {
+                Divider()
+                    .padding(.horizontal, 24)
+
+                HStack(spacing: 4) {
+                    Text("Powered by")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.tertiary)
+
+                    Button("Transmission") {
+                        if let url = URL(string: "https://transmissionbt.com/") {
+                            openURL(url)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(themeManager.accentColor)
+                }
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle("About")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationView {
+        iOSAboutView()
+            .environmentObject(ThemeManager.shared)
+    }
+}
+#endif

--- a/BitDream/Views/iOS/Settings/iOSSettingsView.swift
+++ b/BitDream/Views/iOS/Settings/iOSSettingsView.swift
@@ -87,11 +87,13 @@ struct iOSSettingsView: View {
                 }
 
                 Section(header: Text("About")) {
-                    HStack {
-                        Text("Version")
-                        Spacer()
-                        Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
-                            .foregroundColor(.gray)
+                    NavigationLink(destination: iOSAboutView()) {
+                        HStack {
+                            Text("About BitDream")
+                            Spacer()
+                            Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                                .foregroundColor(.gray)
+                        }
                     }
                 }
             }

--- a/BitDream/Views/macOS/macOSAboutView.swift
+++ b/BitDream/Views/macOS/macOSAboutView.swift
@@ -9,14 +9,8 @@ struct macOSAboutView: View {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
     }
 
-    private var buildNumber: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
-    }
-
     private var copyrightYear: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy"
-        return formatter.string(from: Date())
+        String(Calendar.current.component(.year, from: Date()))
     }
 
     var body: some View {
@@ -49,7 +43,6 @@ struct macOSAboutView: View {
                     .font(.system(size: 11))
                     .foregroundStyle(.primary)
                     .multilineTextAlignment(.center)
-                    .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
 
                 // Version Information - Ghostty style


### PR DESCRIPTION
## Summary
- add a dedicated About screen on iOS and link to it from Settings
- align the macOS About view with the same simplified copyright year handling
- add dark appearance fill metadata for the default app icon