### PR TITLE
Add torrent count to menu bar

### DIFF
--- a/BitDream/AppConfig.swift
+++ b/BitDream/AppConfig.swift
@@ -35,6 +35,7 @@ enum AppDefaults {
     static let themeMode: ThemeMode = .system
     static let showContentTypeIcons: Bool = true
     static let menuBarTransferWidgetEnabled: Bool = true
+    static let menuBarShowActiveCount: Bool = true
     static let menuBarSortMode: MenuBarSortMode = .activity
     static let pollInterval: Double = 5.0
     static let ratioDisplayMode: RatioDisplayMode = .cumulative
@@ -61,6 +62,7 @@ enum UserDefaultsKeys {
     static let torrentListCompactMode = "torrentListCompactMode"
     static let showContentTypeIcons = "showContentTypeIcons"
     static let menuBarTransferWidgetEnabled = "menuBarTransferWidgetEnabled"
+    static let menuBarShowActiveCount = "menuBarShowActiveCount"
     static let menuBarSortMode = "menuBarSortMode"
     static let ratioDisplayMode = "ratioDisplayMode"
     static let selectedHost = "selectedHost"

--- a/BitDream/BitDreamApp.swift
+++ b/BitDream/BitDreamApp.swift
@@ -23,6 +23,7 @@ struct BitDreamApp: App {
     @State private var appearanceHUDText: String = ""
     @State private var hideHUDWork: DispatchWorkItem?
     @AppStorage(UserDefaultsKeys.menuBarTransferWidgetEnabled) private var menuBarTransferWidgetEnabled: Bool = AppDefaults.menuBarTransferWidgetEnabled
+    @AppStorage(UserDefaultsKeys.menuBarShowActiveCount) private var menuBarShowActiveCount: Bool = AppDefaults.menuBarShowActiveCount
 
     #if os(iOS)
     @Environment(\.scenePhase) private var scenePhase
@@ -114,6 +115,9 @@ private extension BitDreamApp {
                 }
                 .onChange(of: menuBarTransferWidgetEnabled) { _, isEnabled in
                     syncMenuBarStatusItem(isEnabled: isEnabled)
+                }
+                .onChange(of: menuBarShowActiveCount) { _, _ in
+                    syncMenuBarStatusItem()
                 }
                 .onReceive(
                     NotificationCenter.default

--- a/BitDream/Views/Shared/Settings/SettingsView.swift
+++ b/BitDream/Views/Shared/Settings/SettingsView.swift
@@ -29,6 +29,7 @@ struct SettingsView: View {
         // Persist AppStorage-backed flags
         UserDefaults.standard.set(AppDefaults.showContentTypeIcons, forKey: UserDefaultsKeys.showContentTypeIcons)
         UserDefaults.standard.set(AppDefaults.menuBarTransferWidgetEnabled, forKey: UserDefaultsKeys.menuBarTransferWidgetEnabled)
+        UserDefaults.standard.set(AppDefaults.menuBarShowActiveCount, forKey: UserDefaultsKeys.menuBarShowActiveCount)
         UserDefaults.standard.set(AppDefaults.menuBarSortMode.rawValue, forKey: UserDefaultsKeys.menuBarSortMode)
         UserDefaults.standard.set(AppDefaults.startupConnectionBehavior.rawValue, forKey: UserDefaultsKeys.startupConnectionBehavior)
 

--- a/BitDream/Views/macOS/MenuBar/MenuBarStatusItemBridge.swift
+++ b/BitDream/Views/macOS/MenuBar/MenuBarStatusItemBridge.swift
@@ -30,6 +30,7 @@ final class MenuBarStatusItemBridge: NSObject, ObservableObject, NSMenuDelegate 
 
         if isEnabled {
             installStatusItemIfNeeded()
+            updateStatusItemButton()
             updateMenuContent()
         } else {
             tearDownStatusItem()
@@ -44,6 +45,7 @@ final class MenuBarStatusItemBridge: NSObject, ObservableObject, NSMenuDelegate 
 
         button.image = NSImage(named: "MenuBarIcon")
         button.image?.isTemplate = true
+        button.imagePosition = .imageLeading
         button.toolTip = "BitDream Torrents"
 
         let menu = NSMenu()
@@ -77,6 +79,28 @@ final class MenuBarStatusItemBridge: NSObject, ObservableObject, NSMenuDelegate 
         item.isEnabled = true
         statusMenu.addItem(item)
         contentMenuItem = item
+    }
+
+    private func updateStatusItemButton() {
+        guard let button = statusItem?.button else { return }
+
+        let showCount = (UserDefaults.standard.object(forKey: UserDefaultsKeys.menuBarShowActiveCount) as? Bool)
+            ?? AppDefaults.menuBarShowActiveCount
+        let count = activeTransferCount()
+        if showCount, count > 0 {
+            // Status bar buttons report a small default font; menu bar text renders at 14pt.
+            button.attributedTitle = NSAttributedString(
+                string: " \(count)",
+                attributes: [.font: NSFont.monospacedDigitSystemFont(ofSize: 14, weight: .regular)]
+            )
+        } else {
+            button.title = ""
+        }
+    }
+
+    private func activeTransferCount() -> Int {
+        guard let store, store.connectionStatus == .connected else { return 0 }
+        return store.torrents.filter(\.isActiveTransfer).count
     }
 
     private func updateMenuContent() {
@@ -125,8 +149,11 @@ final class MenuBarStatusItemBridge: NSObject, ObservableObject, NSMenuDelegate 
         storeChangeCancellable = store.objectWillChange
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                guard let self, self.isMenuOpen else { return }
-                self.scheduleMenuRelayout()
+                guard let self else { return }
+                self.updateStatusItemButton()
+                if self.isMenuOpen {
+                    self.scheduleMenuRelayout()
+                }
             }
     }
 

--- a/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
+++ b/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
@@ -9,6 +9,7 @@ struct macOSGeneralSettingsTab: View {
     @ObservedObject private var themeManager = ThemeManager.shared
     @AppStorage(UserDefaultsKeys.showContentTypeIcons) private var showContentTypeIcons: Bool = AppDefaults.showContentTypeIcons
     @AppStorage(UserDefaultsKeys.menuBarTransferWidgetEnabled) private var menuBarTransferWidgetEnabled: Bool = AppDefaults.menuBarTransferWidgetEnabled
+    @AppStorage(UserDefaultsKeys.menuBarShowActiveCount) private var menuBarShowActiveCount: Bool = AppDefaults.menuBarShowActiveCount
     @AppStorage(UserDefaultsKeys.menuBarSortMode) private var menuBarSortModeRaw: String = AppDefaults.menuBarSortMode.rawValue
     @AppStorage(UserDefaultsKeys.startupConnectionBehavior) private var startupBehaviorRaw: String = AppDefaults.startupConnectionBehavior.rawValue
 
@@ -93,16 +94,22 @@ struct macOSGeneralSettingsTab: View {
                     settingsSection("Menu Bar") {
                         Toggle("Show BitDream in menu bar", isOn: $menuBarTransferWidgetEnabled)
 
-                        HStack {
-                            Text("Sort torrents by")
-                            Spacer()
-                            Picker("", selection: menuBarSortMode) {
-                                ForEach(MenuBarSortMode.allCases, id: \.self) { mode in
-                                    Text(mode.label).tag(mode)
+                        VStack(alignment: .leading, spacing: 12) {
+                            Toggle("Show active torrent count", isOn: $menuBarShowActiveCount)
+
+                            HStack {
+                                Text("Sort torrents by")
+                                Spacer()
+                                Picker("", selection: menuBarSortMode) {
+                                    ForEach(MenuBarSortMode.allCases, id: \.self) { mode in
+                                        Text(mode.label).tag(mode)
+                                    }
                                 }
+                                .pickerStyle(.menu)
                             }
-                            .pickerStyle(.menu)
                         }
+                        .padding(.leading, 20)
+                        .disabled(!menuBarTransferWidgetEnabled)
                     }
 
                     divider


### PR DESCRIPTION
## Summary
- Add an optional active torrent count next to the macOS menu bar icon
- Update the count as torrent activity changes
- Add a Menu Bar setting to toggle the active count display
