### PR TITLE
Update GitHub actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install SwiftLint
         env:
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Write CI build settings override
         env:
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload macOS xcresult bundle
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-xcresult
           path: ${{ runner.temp }}/BitDream.xcresult
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Write CI build settings override
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Derive release metadata
         run: |
@@ -481,7 +481,7 @@ jobs:
           fi
 
       - name: Upload appcast build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sparkle-appcast-${{ github.ref_name }}
           path: |
@@ -489,16 +489,16 @@ jobs:
             ${{ runner.temp }}/generate-appcast.log
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: pages
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Cleanup signing keychain
         if: always()


### PR DESCRIPTION
## What changed

Updated GitHub-owned workflow actions to Node 24-compatible releases:

- `actions/checkout@v7`
- `actions/upload-artifact@v7`
- `actions/configure-pages@v6`
- `actions/upload-pages-artifact@v5`
- `actions/deploy-pages@v5`

## Why

GitHub Actions is moving JavaScript actions from Node 20 to Node 24. These updates remove the deprecated Node 20 action pins without using the insecure Node 20 fallback flag.
