### PR TITLE
Update sparkle to 2.9.4

### DIFF
--- a/BitDream.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BitDream.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
-        "version" : "2.9.0"
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     }
   ],


### PR DESCRIPTION
## summary
- update Sparkle SwiftPM pin from 2.9.0 to 2.9.4

## validation
- xcodebuild package resolution
- macOS debug build
- iOS generic build
- macOS tests: 154 passed
- swiftlint ran; existing unrelated type_body_length violations remain in dirty macOS view files