### PR TITLE
Add Dock badge setting

### DIFF
--- a/BitDream/AppConfig.swift
+++ b/BitDream/AppConfig.swift
@@ -37,6 +37,7 @@ enum AppDefaults {
     static let menuBarTransferWidgetEnabled: Bool = true
     static let menuBarShowActiveCount: Bool = true
     static let menuBarSortMode: MenuBarSortMode = .activity
+    static let dockShowCompletedBadge: Bool = true
     static let pollInterval: Double = 5.0
     static let ratioDisplayMode: RatioDisplayMode = .cumulative
     static let startupConnectionBehavior: StartupConnectionBehavior = .lastUsed
@@ -64,6 +65,7 @@ enum UserDefaultsKeys {
     static let menuBarTransferWidgetEnabled = "menuBarTransferWidgetEnabled"
     static let menuBarShowActiveCount = "menuBarShowActiveCount"
     static let menuBarSortMode = "menuBarSortMode"
+    static let dockShowCompletedBadge = "dockShowCompletedBadge"
     static let ratioDisplayMode = "ratioDisplayMode"
     static let selectedHost = "selectedHost"
     static let startupConnectionBehavior = "startupConnectionBehavior"

--- a/BitDream/BitDreamApp.swift
+++ b/BitDream/BitDreamApp.swift
@@ -15,6 +15,7 @@ struct BitDreamApp: App {
     #if os(macOS)
     @NSApplicationDelegateAdaptor(AppFileOpenDelegate.self) private var appFileOpenDelegate
     @StateObject private var menuBarStatusItemController = MenuBarStatusItemBridge()
+    @StateObject private var dockBadgeController = DockBadgeController()
     @StateObject private var appUpdater = AppUpdater()
     #endif
 
@@ -111,6 +112,7 @@ private extension BitDreamApp {
                     appFileOpenDelegate.configure(with: store)
                     ensureStartupConnectionBehaviorApplied(store: store, modelContext: persistenceController.container.mainContext)
                     syncMenuBarStatusItem()
+                    dockBadgeController.configure(store: store)
                     appUpdater.start()
                 }
                 .onChange(of: menuBarTransferWidgetEnabled) { _, isEnabled in

--- a/BitDream/Views/Shared/ContentView.swift
+++ b/BitDream/Views/Shared/ContentView.swift
@@ -320,20 +320,6 @@ extension Array where Element == Torrent {
     }
 }
 
-#if os(macOS)
-// Helper function to update the app badge on macOS
-@MainActor
-func updateMacOSAppBadge(count: Int) {
-    NSApplication.shared.dockTile.badgeLabel = count > 0 ? "\(count)" : ""
-}
-
-// Helper function to get completed torrents count
-@MainActor
-func getCompletedTorrentsCount(in store: TransmissionStore) -> Int {
-    return store.torrents.filter { $0.statusCalc == .complete }.count
-}
-#endif
-
 // Helper function to calculate total ratio across all torrents
 @MainActor
 func calculateTotalRatio(store: TransmissionStore) -> Double {

--- a/BitDream/Views/Shared/Settings/SettingsView.swift
+++ b/BitDream/Views/Shared/Settings/SettingsView.swift
@@ -31,6 +31,7 @@ struct SettingsView: View {
         UserDefaults.standard.set(AppDefaults.menuBarTransferWidgetEnabled, forKey: UserDefaultsKeys.menuBarTransferWidgetEnabled)
         UserDefaults.standard.set(AppDefaults.menuBarShowActiveCount, forKey: UserDefaultsKeys.menuBarShowActiveCount)
         UserDefaults.standard.set(AppDefaults.menuBarSortMode.rawValue, forKey: UserDefaultsKeys.menuBarSortMode)
+        UserDefaults.standard.set(AppDefaults.dockShowCompletedBadge, forKey: UserDefaultsKeys.dockShowCompletedBadge)
         UserDefaults.standard.set(AppDefaults.startupConnectionBehavior.rawValue, forKey: UserDefaultsKeys.startupConnectionBehavior)
 
         // Poll interval via TransmissionStore API

--- a/BitDream/Views/macOS/DockBadgeController.swift
+++ b/BitDream/Views/macOS/DockBadgeController.swift
@@ -1,0 +1,59 @@
+#if os(macOS)
+import AppKit
+import Combine
+import SwiftUI
+
+// Keeps the Dock icon badge in sync with the completed torrent count,
+// independent of the main window's lifecycle. The badge reflects live app
+// state, so NSDockTile is used rather than UNUserNotificationCenter's
+// badge APIs (which target persistent, notification-driven unread counts).
+@MainActor
+final class DockBadgeController: ObservableObject {
+    private weak var store: TransmissionStore?
+    private var cancellables = Set<AnyCancellable>()
+
+    func configure(store: TransmissionStore) {
+        if self.store !== store || cancellables.isEmpty {
+            self.store = store
+            observeChanges(store)
+        }
+        refresh()
+    }
+
+    private func observeChanges(_ store: TransmissionStore) {
+        cancellables.removeAll()
+
+        store.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.refresh()
+            }
+            .store(in: &cancellables)
+
+        // Reflect settings changes immediately, even when no window is open.
+        NotificationCenter.default
+            .publisher(for: UserDefaults.didChangeNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.refresh()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func refresh() {
+        let isEnabled = (UserDefaults.standard.object(forKey: UserDefaultsKeys.dockShowCompletedBadge) as? Bool)
+            ?? AppDefaults.dockShowCompletedBadge
+        let count = isEnabled ? completedTorrentsCount() : 0
+        let badgeLabel = count > 0 ? "\(count)" : nil
+
+        if NSApplication.shared.dockTile.badgeLabel != badgeLabel {
+            NSApplication.shared.dockTile.badgeLabel = badgeLabel
+        }
+    }
+
+    private func completedTorrentsCount() -> Int {
+        guard let store, store.connectionStatus == .connected else { return 0 }
+        return store.torrents.filter { $0.statusCalc == .complete }.count
+    }
+}
+#endif

--- a/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
+++ b/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
@@ -12,6 +12,7 @@ struct macOSGeneralSettingsTab: View {
     @AppStorage(UserDefaultsKeys.menuBarShowActiveCount) private var menuBarShowActiveCount: Bool = AppDefaults.menuBarShowActiveCount
     @AppStorage(UserDefaultsKeys.menuBarSortMode) private var menuBarSortModeRaw: String = AppDefaults.menuBarSortMode.rawValue
     @AppStorage(UserDefaultsKeys.startupConnectionBehavior) private var startupBehaviorRaw: String = AppDefaults.startupConnectionBehavior.rawValue
+    @AppStorage(UserDefaultsKeys.dockShowCompletedBadge) private var dockShowCompletedBadge: Bool = AppDefaults.dockShowCompletedBadge
 
     private var menuBarSortMode: Binding<MenuBarSortMode> {
         Binding<MenuBarSortMode>(
@@ -160,8 +161,8 @@ struct macOSGeneralSettingsTab: View {
                     divider
 
                     settingsSection("Notifications") {
-                        Toggle("Show app badge for completed torrents", isOn: .constant(true))
-                            .disabled(true)
+                        Toggle("Show Dock badge for completed torrents", isOn: $dockShowCompletedBadge)
+                            .help("Show the number of completed torrents on BitDream's Dock icon.")
 
                         Toggle("Show notifications for completed torrents", isOn: .constant(false))
                             .disabled(true)

--- a/BitDream/Views/macOS/macOSContentView.swift
+++ b/BitDream/Views/macOS/macOSContentView.swift
@@ -91,12 +91,6 @@ struct macOSContentView: View {
                 }
             }
         }
-        .onReceive(store.$torrents) { _ in
-            updateAppBadge()
-        }
-        .onAppear {
-            updateAppBadge()
-        }
     }
 
     // Enhanced view (state changes + search + toolbar)
@@ -266,10 +260,6 @@ private extension macOSContentView {
         return store.torrents.first { $0.id == selectedId }
     }
 
-    var completedTorrentsCount: Int {
-        getCompletedTorrentsCount(in: store)
-    }
-
     var hasActiveFilters: Bool {
         !includedLabels.isEmpty || !excludedLabels.isEmpty || showOnlyNoLabels
     }
@@ -329,10 +319,6 @@ private extension macOSContentView {
             torrentMatchesSearch(torrent, query: searchText)
         }
         return filteredBySearch.count
-    }
-
-    func updateAppBadge() {
-        updateMacOSAppBadge(count: completedTorrentsCount)
     }
 
     func removeSelectedTorrentsFromMenu(deleteData: Bool) {


### PR DESCRIPTION
## Summary
- Add a settings toggle and default for showing the macOS completed torrent Dock badge
- Move completed torrent Dock badge updates into a macOS app-level controller
- Remove badge updates from the main macOS content view lifecycle
