### PR TITLE
Add iOS label filtering

### DIFF
--- a/BitDream/Torrent/TorrentFiltering.swift
+++ b/BitDream/Torrent/TorrentFiltering.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+enum TorrentLabelRule: String {
+    case none = "No Filter"
+    case include = "Include"
+    case exclude = "Exclude"
+
+    var next: Self {
+        switch self {
+        case .none:
+            return .include
+        case .include:
+            return .exclude
+        case .exclude:
+            return .none
+        }
+    }
+}
+
+struct TorrentLabelFilter: Equatable {
+    var includedLabels: Set<String> = []
+    var excludedLabels: Set<String> = []
+    var showsUnlabeledOnly = false
+
+    var activeCount: Int {
+        includedLabels.count + excludedLabels.count + (showsUnlabeledOnly ? 1 : 0)
+    }
+
+    var isActive: Bool {
+        activeCount > 0
+    }
+
+    func rule(for label: String) -> TorrentLabelRule {
+        if includedLabels.contains(caseInsensitive: label) {
+            return .include
+        }
+        if excludedLabels.contains(caseInsensitive: label) {
+            return .exclude
+        }
+        return .none
+    }
+
+    mutating func setRule(_ rule: TorrentLabelRule, for label: String) {
+        includedLabels.remove(caseInsensitive: label)
+        excludedLabels.remove(caseInsensitive: label)
+
+        switch rule {
+        case .none:
+            break
+        case .include:
+            includedLabels.insert(label)
+            showsUnlabeledOnly = false
+        case .exclude:
+            excludedLabels.insert(label)
+            showsUnlabeledOnly = false
+        }
+    }
+
+    mutating func advanceRule(for label: String) {
+        setRule(rule(for: label).next, for: label)
+    }
+
+    mutating func setShowsUnlabeledOnly(_ showsUnlabeledOnly: Bool) {
+        self.showsUnlabeledOnly = showsUnlabeledOnly
+
+        if showsUnlabeledOnly {
+            includedLabels.removeAll()
+            excludedLabels.removeAll()
+        }
+    }
+
+    mutating func reconcile(with availableLabels: [String]) {
+        let includedKeys = Set(includedLabels.map { $0.lowercased() })
+        let excludedKeys = Set(excludedLabels.map { $0.lowercased() })
+
+        includedLabels = Set(
+            availableLabels.filter { includedKeys.contains($0.lowercased()) }
+        )
+        excludedLabels = Set(
+            availableLabels.filter { excludedKeys.contains($0.lowercased()) }
+        )
+    }
+
+    mutating func clear() {
+        includedLabels.removeAll()
+        excludedLabels.removeAll()
+        showsUnlabeledOnly = false
+    }
+}
+
+struct TorrentDisplayOptions {
+    let statusFilter: [TorrentStatusCalc]
+    let labelFilter: TorrentLabelFilter
+    let searchText: String
+    let sortProperty: SortProperty
+    let sortOrder: SortOrder
+}
+
+extension Array where Element == Torrent {
+    func filtered(by statusFilter: [TorrentStatusCalc]) -> [Torrent] {
+        guard statusFilter != TorrentStatusCalc.allCases else {
+            return self
+        }
+
+        return filter { statusFilter.contains($0.statusCalc) }
+    }
+
+    func filtered(by labelFilter: TorrentLabelFilter) -> [Torrent] {
+        guard labelFilter.isActive else {
+            return self
+        }
+
+        let includedLabels = Set(labelFilter.includedLabels.map { $0.lowercased() })
+        let excludedLabels = Set(labelFilter.excludedLabels.map { $0.lowercased() })
+
+        return filter { torrent in
+            if labelFilter.showsUnlabeledOnly {
+                return torrent.labels.isEmpty
+            }
+
+            let torrentLabels = Set(torrent.labels.map { $0.lowercased() })
+            let matchesIncludedLabel = includedLabels.isEmpty
+                || !torrentLabels.isDisjoint(with: includedLabels)
+            let matchesExcludedLabel = !torrentLabels.isDisjoint(with: excludedLabels)
+
+            return matchesIncludedLabel && !matchesExcludedLabel
+        }
+    }
+
+    func filtered(
+        by statusFilter: [TorrentStatusCalc],
+        labelFilter: TorrentLabelFilter,
+        searchText: String
+    ) -> [Torrent] {
+        let filteredByStatusAndLabel = filtered(by: statusFilter)
+            .filtered(by: labelFilter)
+
+        guard !searchText.isEmpty else {
+            return filteredByStatusAndLabel
+        }
+
+        return filteredByStatusAndLabel.filter {
+            $0.name.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+}
+
+func filterAndSortTorrents(
+    _ torrents: [Torrent],
+    options: TorrentDisplayOptions
+) -> [Torrent] {
+    let filteredTorrents = torrents.filtered(
+        by: options.statusFilter,
+        labelFilter: options.labelFilter,
+        searchText: options.searchText
+    )
+
+    return sortTorrents(
+        filteredTorrents,
+        by: options.sortProperty,
+        order: options.sortOrder
+    )
+}
+
+private extension Set where Element == String {
+    func contains(caseInsensitive value: String) -> Bool {
+        contains { $0.localizedCaseInsensitiveCompare(value) == .orderedSame }
+    }
+
+    mutating func remove(caseInsensitive value: String) {
+        guard let matchingValue = first(where: {
+            $0.localizedCaseInsensitiveCompare(value) == .orderedSame
+        }) else {
+            return
+        }
+
+        remove(matchingValue)
+    }
+}

--- a/BitDream/Views/Shared/ContentView.swift
+++ b/BitDream/Views/Shared/ContentView.swift
@@ -283,42 +283,6 @@ enum SidebarSelection: String, CaseIterable, Identifiable {
     }
 }
 
-// MARK: - Shared Extensions
-
-// Extension to filter and sort torrents
-extension Array where Element == Torrent {
-    func filtered(by filterSelection: [TorrentStatusCalc]) -> [Torrent] {
-        if filterSelection == TorrentStatusCalc.allCases {
-            return self
-        }
-        return self.filter { torrent in
-            filterSelection.contains { $0 == torrent.statusCalc }
-        }
-    }
-
-    func filtered(by selectedLabels: Set<String>, enabled: Bool) -> [Torrent] {
-        guard enabled else { return self }
-        guard !selectedLabels.isEmpty else { return self }
-
-        return self.filter { torrent in
-            // Show torrents that have at least one of the selected labels
-            torrent.labels.contains { torrentLabel in
-                selectedLabels.contains { selectedLabel in
-                    torrentLabel.lowercased() == selectedLabel.lowercased()
-                }
-            }
-        }
-    }
-
-    func filtered(by statusFilter: [TorrentStatusCalc], labelFilter: Set<String>, labelFilterEnabled: Bool) -> [Torrent] {
-        return self.filtered(by: statusFilter).filtered(by: labelFilter, enabled: labelFilterEnabled)
-    }
-
-    func sorted(by property: SortProperty, order: SortOrder) -> [Torrent] {
-        return sortTorrents(self, by: property, order: order)
-    }
-}
-
 // Helper function to calculate total ratio across all torrents
 @MainActor
 func calculateTotalRatio(store: TransmissionStore) -> Double {

--- a/BitDream/Views/iOS/iOSContentView.swift
+++ b/BitDream/Views/iOS/iOSContentView.swift
@@ -9,9 +9,10 @@ struct iOSContentView: View {
     // Store the selected torrent IDs
     @State private var selectedTorrentIds: Set<Int> = []
 
-    @State var sortProperty: SortProperty = UserDefaults.standard.sortProperty
-    @State var sortOrder: SortOrder = UserDefaults.standard.sortOrder
-    @State var filterBySelection: [TorrentStatusCalc] = TorrentStatusCalc.allCases
+    @State private var sortProperty: SortProperty = UserDefaults.standard.sortProperty
+    @State private var sortOrder: SortOrder = UserDefaults.standard.sortOrder
+    @State private var filterBySelection: [TorrentStatusCalc] = TorrentStatusCalc.allCases
+    @State private var labelFilter = TorrentLabelFilter()
     @AppStorage(UserDefaultsKeys.showContentTypeIcons) private var showContentTypeIcons: Bool = true
     @State private var searchText: String = ""
     @State private var showPrefs: Bool = false
@@ -59,6 +60,13 @@ struct iOSContentView: View {
                 Text("Select a Dream")
             }
         }
+        .onChange(of: store.availableLabels) { _, availableLabels in
+            reconcileSelectedLabels(with: availableLabels)
+        }
+        .onChange(of: store.host?.serverID) { _, _ in
+            labelFilter.clear()
+            selectedTorrentIds.removeAll()
+        }
         .sheet(isPresented: $store.setup, content: {
             iOSServerEditor(store: store, hosts: hosts, host: nil)
         })
@@ -79,6 +87,19 @@ struct iOSContentView: View {
 }
 
 private extension iOSContentView {
+    var displayedTorrents: [Torrent] {
+        filterAndSortTorrents(
+            store.torrents,
+            options: TorrentDisplayOptions(
+                statusFilter: filterBySelection,
+                labelFilter: labelFilter,
+                searchText: searchText,
+                sortProperty: sortProperty,
+                sortOrder: sortOrder
+            )
+        )
+    }
+
     var selectedTorrentsSet: Set<Torrent> {
         Set(selectedTorrentIds.compactMap { id in
             store.torrents.first { $0.id == id }
@@ -92,14 +113,7 @@ private extension iOSContentView {
                     .foregroundColor(.gray)
                     .padding()
             } else {
-                let filteredByStatus = store.torrents.filtered(by: filterBySelection)
-                let filteredBySearch = searchText.isEmpty
-                    ? filteredByStatus
-                    : filteredByStatus.filter { torrent in
-                        torrent.name.localizedCaseInsensitiveContains(searchText)
-                    }
-                let sortedTorrents = sortTorrents(filteredBySearch, by: sortProperty, order: sortOrder)
-                ForEach(sortedTorrents, id: \.id) { torrent in
+                ForEach(displayedTorrents, id: \.id) { torrent in
                     TorrentListRow(
                         torrent: torrent,
                         store: store,
@@ -172,7 +186,15 @@ private extension iOSContentView {
                     Image(systemName: "slider.horizontal.3")
                 }
                 .popover(isPresented: $showPrefs) {
-                    prefsPopoverContent
+                    iOSFilterAndSortView(
+                        statusFilter: $filterBySelection,
+                        labelFilter: $labelFilter,
+                        sortProperty: $sortProperty,
+                        sortOrder: $sortOrder,
+                        availableLabels: store.availableLabels,
+                        labelCounts: availableLabelCounts,
+                        noLabelCount: store.torrents.count(where: { $0.labels.isEmpty })
+                    )
                 }
             }
 
@@ -190,69 +212,6 @@ private extension iOSContentView {
         }
     }
 
-    var prefsPopoverContent: some View {
-        NavigationStack {
-            List {
-                Section {
-                    Button("All") {
-                        filterBySelection = TorrentStatusCalc.allCases
-                    }
-                    Button("Downloading") {
-                        filterBySelection = [.downloading]
-                    }
-                    Button("Complete") {
-                        filterBySelection = [.complete]
-                    }
-                    Button("Paused") {
-                        filterBySelection = [.paused]
-                    }
-                    Button("Exclude Complete") {
-                        filterBySelection = TorrentStatusCalc.allCases.filter { $0 != .complete }
-                    }
-                } header: {
-                    Text("Filter")
-                }
-
-                Section {
-                    ForEach(SortProperty.allCases, id: \.self) { property in
-                        Button {
-                            sortProperty = property
-                        } label: {
-                            HStack {
-                                Text(property.rawValue)
-                                Spacer()
-                                if sortProperty == property {
-                                    Image(systemName: "checkmark")
-                                        .foregroundStyle(.accent)
-                                }
-                            }
-                        }
-                    }
-                    Picker("Order", selection: $sortOrder) {
-                        Text("Ascending").tag(SortOrder.ascending)
-                        Text("Descending").tag(SortOrder.descending)
-                    }
-                    .pickerStyle(.segmented)
-                    .listRowSeparator(.hidden)
-                } header: {
-                    Text("Sort")
-                }
-            }
-            .buttonStyle(.plain)
-            .listStyle(.insetGrouped)
-            .navigationTitle("Filter & Sort")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") {
-                        showPrefs = false
-                    }
-                }
-            }
-        }
-        .presentationDragIndicator(.visible)
-    }
-
     func pauseAllTorrents() {
         performTransmissionDebugAction(
             .pauseAllTorrents,
@@ -266,6 +225,23 @@ private extension iOSContentView {
             .resumeAllTorrents,
             store: store,
             operation: { try await store.resumeAllTorrents() }
+        )
+    }
+
+    func reconcileSelectedLabels(with availableLabels: [String]) {
+        var reconciledFilter = labelFilter
+        reconciledFilter.reconcile(with: availableLabels)
+
+        if reconciledFilter != labelFilter {
+            labelFilter = reconciledFilter
+        }
+    }
+
+    var availableLabelCounts: [String: Int] {
+        Dictionary(
+            uniqueKeysWithValues: store.availableLabels.map { label in
+                (label, store.torrentCount(for: label))
+            }
         )
     }
 }

--- a/BitDream/Views/iOS/iOSFilterAndSortView.swift
+++ b/BitDream/Views/iOS/iOSFilterAndSortView.swift
@@ -1,0 +1,235 @@
+import SwiftUI
+
+#if os(iOS)
+struct iOSFilterAndSortView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @Binding var statusFilter: [TorrentStatusCalc]
+    @Binding var labelFilter: TorrentLabelFilter
+    @Binding var sortProperty: SortProperty
+    @Binding var sortOrder: SortOrder
+
+    let availableLabels: [String]
+    let labelCounts: [String: Int]
+    let noLabelCount: Int
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Filter") {
+                    Picker("Status", selection: statusOptionBinding) {
+                        ForEach(iOSStatusFilterOption.allCases) { option in
+                            Text(option.rawValue).tag(option)
+                        }
+                    }
+                    .pickerStyle(.navigationLink)
+
+                    NavigationLink {
+                        iOSLabelFilterView(
+                            labelFilter: $labelFilter,
+                            availableLabels: availableLabels,
+                            labelCounts: labelCounts,
+                            noLabelCount: noLabelCount
+                        )
+                    } label: {
+                        LabeledContent("Labels", value: labelSelectionSummary)
+                    }
+                }
+
+                Section("Sort") {
+                    Picker("Sort By", selection: $sortProperty) {
+                        ForEach(SortProperty.allCases, id: \.self) { property in
+                            Text(property.rawValue).tag(property)
+                        }
+                    }
+                    .pickerStyle(.navigationLink)
+
+                    Picker("Order", selection: $sortOrder) {
+                        Text("Ascending").tag(SortOrder.ascending)
+                        Text("Descending").tag(SortOrder.descending)
+                    }
+                    .pickerStyle(.navigationLink)
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Filter & Sort")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done", action: dismiss.callAsFunction)
+                }
+            }
+        }
+        .presentationDragIndicator(.visible)
+    }
+}
+
+private extension iOSFilterAndSortView {
+    var statusOptionBinding: Binding<iOSStatusFilterOption> {
+        Binding(
+            get: {
+                iOSStatusFilterOption.allCases.first { $0.statuses == statusFilter } ?? .all
+            },
+            set: { statusFilter = $0.statuses }
+        )
+    }
+
+    var labelSelectionSummary: String {
+        switch labelFilter.activeCount {
+        case 0:
+            return "None"
+        case 1 where labelFilter.showsUnlabeledOnly:
+            return "No labels"
+        default:
+            return "\(labelFilter.activeCount) Active"
+        }
+    }
+}
+
+private struct iOSLabelFilterView: View {
+    @Binding var labelFilter: TorrentLabelFilter
+
+    let availableLabels: [String]
+    let labelCounts: [String: Int]
+    let noLabelCount: Int
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(availableLabels, id: \.self) { label in
+                    let rule = labelFilter.rule(for: label)
+                    Button {
+                        labelFilter.advanceRule(for: label)
+                    } label: {
+                        iOSLabelRuleRow(
+                            label: label,
+                            count: labelCounts[label, default: 0],
+                            rule: rule
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .listRowSeparator(
+                        label == availableLabels.last ? .visible : .hidden,
+                        edges: .bottom
+                    )
+                    .accessibilityValue(rule.rawValue)
+                    .accessibilityHint("Cycles between no filter, include, and exclude")
+                }
+
+                Button {
+                    labelFilter.setShowsUnlabeledOnly(!labelFilter.showsUnlabeledOnly)
+                } label: {
+                    iOSNoLabelsFilterRow(
+                        count: noLabelCount,
+                        isSelected: labelFilter.showsUnlabeledOnly
+                    )
+                }
+                .buttonStyle(.plain)
+                .listRowSeparator(.hidden)
+                .accessibilityValue(labelFilter.showsUnlabeledOnly ? "Selected" : "Not selected")
+            }
+
+            if labelFilter.isActive {
+                Section {
+                    Button("Clear All Filters") {
+                        labelFilter.clear()
+                    }
+                }
+            }
+        }
+        .navigationTitle("Labels")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct iOSLabelRuleRow: View {
+    let label: String
+    let count: Int
+    let rule: TorrentLabelRule
+
+    var body: some View {
+        HStack {
+            Image(systemName: rule.systemImage)
+                .foregroundStyle(rule.color)
+                .accessibilityHidden(true)
+            Text(label)
+                .foregroundStyle(.primary)
+            Spacer()
+            Text("\(count)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .contentShape(.rect)
+    }
+}
+
+private extension TorrentLabelRule {
+    var systemImage: String {
+        switch self {
+        case .none:
+            return "circle"
+        case .include:
+            return "checkmark.circle.fill"
+        case .exclude:
+            return "minus.circle.fill"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .none:
+            return .secondary
+        case .include:
+            return .accent
+        case .exclude:
+            return .red
+        }
+    }
+}
+
+private struct iOSNoLabelsFilterRow: View {
+    let count: Int
+    let isSelected: Bool
+
+    var body: some View {
+        HStack {
+            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                .foregroundStyle(isSelected ? Color.accent : Color.secondary)
+                .accessibilityHidden(true)
+            Text("No labels")
+                .foregroundStyle(.primary)
+                .italic()
+            Spacer()
+            Text("\(count)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .contentShape(.rect)
+    }
+}
+
+private enum iOSStatusFilterOption: String, CaseIterable, Identifiable {
+    case all = "All"
+    case downloading = "Downloading"
+    case complete = "Complete"
+    case paused = "Paused"
+    case excludeComplete = "Exclude Complete"
+
+    var id: Self { self }
+
+    var statuses: [TorrentStatusCalc] {
+        switch self {
+        case .all:
+            return TorrentStatusCalc.allCases
+        case .downloading:
+            return [.downloading]
+        case .complete:
+            return [.complete]
+        case .paused:
+            return [.paused]
+        case .excludeComplete:
+            return TorrentStatusCalc.allCases.filter { $0 != .complete }
+        }
+    }
+}
+#endif

--- a/BitDreamTests/Views/TorrentFilteringTests.swift
+++ b/BitDreamTests/Views/TorrentFilteringTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+@testable import BitDream
+
+@MainActor
+final class TorrentFilteringTests: XCTestCase {
+    func testEmptyLabelSelectionDoesNotRestrictResults() {
+        let torrents = [
+            makeTorrent(id: 1, name: "One", labels: ["movie"]),
+            makeTorrent(id: 2, name: "Two", labels: [])
+        ]
+
+        XCTAssertEqual(
+            torrents.filtered(by: TorrentLabelFilter()).map(\.id),
+            [1, 2]
+        )
+    }
+
+    func testLabelFilteringMatchesAnySelectedLabelCaseInsensitively() {
+        let torrents = [
+            makeTorrent(id: 1, name: "Movie", labels: ["Movie"]),
+            makeTorrent(id: 2, name: "Series", labels: ["TV"]),
+            makeTorrent(id: 3, name: "Album", labels: ["music"])
+        ]
+
+        let filtered = torrents.filtered(
+            by: TorrentLabelFilter(includedLabels: ["movie", "tv"])
+        )
+
+        XCTAssertEqual(filtered.map(\.id), [1, 2])
+    }
+
+    func testUnlabeledSelectionMatchesTorrentsWithoutLabels() {
+        let torrents = [
+            makeTorrent(id: 1, name: "Movie", labels: ["movie"]),
+            makeTorrent(id: 2, name: "Unlabeled", labels: [])
+        ]
+
+        let filtered = torrents.filtered(
+            by: TorrentLabelFilter(showsUnlabeledOnly: true)
+        )
+
+        XCTAssertEqual(filtered.map(\.id), [2])
+    }
+
+    func testExcludedLabelsRemoveMatchingTorrentsCaseInsensitively() {
+        let torrents = [
+            makeTorrent(id: 1, name: "Movie", labels: ["movie"]),
+            makeTorrent(id: 2, name: "Series", labels: ["tv"]),
+            makeTorrent(id: 3, name: "Unlabeled", labels: [])
+        ]
+
+        let filtered = torrents.filtered(
+            by: TorrentLabelFilter(excludedLabels: ["TV"])
+        )
+
+        XCTAssertEqual(filtered.map(\.id), [1, 3])
+    }
+
+    func testIncludedAndExcludedLabelsComposeWithAndSemantics() {
+        let torrents = [
+            makeTorrent(id: 1, name: "Movie", labels: ["movie"]),
+            makeTorrent(id: 2, name: "Movie Series", labels: ["movie", "tv"]),
+            makeTorrent(id: 3, name: "Series", labels: ["tv"]),
+            makeTorrent(id: 4, name: "Unlabeled", labels: [])
+        ]
+
+        let filtered = torrents.filtered(
+            by: TorrentLabelFilter(
+                includedLabels: ["movie"],
+                excludedLabels: ["tv"]
+            )
+        )
+
+        XCTAssertEqual(filtered.map(\.id), [1])
+    }
+
+    func testUnlabeledAndLabelRulesAreMutuallyExclusive() {
+        var labelFilter = TorrentLabelFilter(includedLabels: ["movie"])
+
+        labelFilter.setShowsUnlabeledOnly(true)
+
+        XCTAssertTrue(labelFilter.includedLabels.isEmpty)
+        XCTAssertTrue(labelFilter.excludedLabels.isEmpty)
+        XCTAssertTrue(labelFilter.showsUnlabeledOnly)
+
+        labelFilter.setRule(.exclude, for: "tv")
+
+        XCTAssertFalse(labelFilter.showsUnlabeledOnly)
+        XCTAssertEqual(labelFilter.excludedLabels, ["tv"])
+    }
+
+    func testAdvancingLabelRuleMatchesMacOSTriStateOrder() {
+        var labelFilter = TorrentLabelFilter()
+
+        labelFilter.advanceRule(for: "movie")
+        XCTAssertEqual(labelFilter.rule(for: "movie"), .include)
+
+        labelFilter.advanceRule(for: "movie")
+        XCTAssertEqual(labelFilter.rule(for: "movie"), .exclude)
+
+        labelFilter.advanceRule(for: "movie")
+        XCTAssertEqual(labelFilter.rule(for: "movie"), .none)
+    }
+
+    func testStatusLabelAndSearchFiltersComposeWithAndSemantics() {
+        let torrents = [
+            makeTorrent(
+                id: 1,
+                name: "Ubuntu Desktop",
+                labels: ["linux"],
+                status: .downloading,
+                percentDone: 0.4
+            ),
+            makeTorrent(
+                id: 2,
+                name: "Ubuntu Server",
+                labels: ["linux"],
+                status: .stopped,
+                percentDone: 1
+            ),
+            makeTorrent(
+                id: 3,
+                name: "Fedora Workstation",
+                labels: ["linux"],
+                status: .downloading,
+                percentDone: 0.4
+            ),
+            makeTorrent(
+                id: 4,
+                name: "Ubuntu Documentary",
+                labels: ["movies"],
+                status: .downloading,
+                percentDone: 0.4
+            )
+        ]
+
+        let filtered = torrents.filtered(
+            by: [.downloading],
+            labelFilter: TorrentLabelFilter(includedLabels: ["LINUX"]),
+            searchText: "ubuntu"
+        )
+
+        XCTAssertEqual(filtered.map(\.id), [1])
+    }
+
+    func testFilterAndSortSortsOnlyMatchingTorrents() {
+        let torrents = [
+            makeTorrent(id: 1, name: "Zulu", labels: ["selected"]),
+            makeTorrent(id: 2, name: "Alpha", labels: ["selected"]),
+            makeTorrent(id: 3, name: "Bravo", labels: ["other"])
+        ]
+
+        let displayed = filterAndSortTorrents(
+            torrents,
+            options: TorrentDisplayOptions(
+                statusFilter: TorrentStatusCalc.allCases,
+                labelFilter: TorrentLabelFilter(includedLabels: ["selected"]),
+                searchText: "",
+                sortProperty: .name,
+                sortOrder: .ascending
+            )
+        )
+
+        XCTAssertEqual(displayed.map(\.id), [2, 1])
+    }
+}
+
+private extension TorrentFilteringTests {
+    func makeTorrent(
+        id: Int,
+        name: String,
+        labels: [String],
+        status: TorrentStatus = .downloading,
+        percentDone: Double = 0.5
+    ) -> Torrent {
+        Torrent(
+            activityDate: 0,
+            addedDate: 0,
+            desiredAvailable: 0,
+            error: 0,
+            errorString: "",
+            eta: 0,
+            haveUnchecked: 0,
+            haveValid: 0,
+            id: id,
+            isFinished: percentDone == 1,
+            isStalled: false,
+            labels: labels,
+            leftUntilDone: 0,
+            magnetLink: "",
+            metadataPercentComplete: 1,
+            name: name,
+            peersConnected: 0,
+            peersGettingFromUs: 0,
+            peersSendingToUs: 0,
+            percentDone: percentDone,
+            primaryMimeType: nil,
+            downloadDir: "/downloads",
+            queuePosition: 0,
+            rateDownload: 0,
+            rateUpload: 0,
+            sizeWhenDone: 0,
+            status: status.rawValue,
+            totalSize: 0,
+            uploadRatioRaw: 0,
+            uploadedEver: 0,
+            downloadedEver: 0
+        )
+    }
+}


### PR DESCRIPTION
Add label filtering to the existing iOS Filter & Sort flow with macOS-equivalent include, exclude, and no-label behavior. Search, status filters, label filters, and sorting compose predictably.
