### PR TITLE
Improve iPhone navigation

### DIFF
--- a/BitDream/Views/Shared/TorrentListRow.swift
+++ b/BitDream/Views/Shared/TorrentListRow.swift
@@ -9,7 +9,12 @@ struct TorrentListRow: View {
 
     var body: some View {
         #if os(iOS)
-        iOSTorrentListRow(torrent: torrent, store: store, showContentTypeIcons: showContentTypeIcons)
+        iOSTorrentListRow(
+            torrent: torrent,
+            store: store,
+            showContentTypeIcons: showContentTypeIcons,
+            destinationID: nil
+        )
         #elseif os(macOS)
         macOSTorrentListExpanded(torrent: torrent, store: store, selectedTorrents: selectedTorrents, showContentTypeIcons: showContentTypeIcons)
         #endif

--- a/BitDream/Views/iOS/iOSContentView.swift
+++ b/BitDream/Views/iOS/iOSContentView.swift
@@ -3,11 +3,13 @@ import Foundation
 
 #if os(iOS)
 struct iOSContentView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     let hosts: [Host]
     @ObservedObject var store: TransmissionStore
 
-    // Store the selected torrent IDs
-    @State private var selectedTorrentIds: Set<Int> = []
+    // Store the selected torrent ID
+    @State private var selectedTorrentID: Int?
 
     @State private var sortProperty: SortProperty = UserDefaults.standard.sortProperty
     @State private var sortOrder: SortOrder = UserDefaults.standard.sortOrder
@@ -18,46 +20,11 @@ struct iOSContentView: View {
     @State private var showPrefs: Bool = false
 
     var body: some View {
-        NavigationSplitView {
-            VStack(spacing: 0) {
-                StatsHeaderView(store: store)
-
-                Group {
-                    if store.host != nil, store.connectionStatus != .connected {
-                        iOSConnectionBannerView(store: store)
-                            .transition(.move(edge: .top).combined(with: .opacity))
-                    }
-                }
-                .animation(.default, value: store.connectionStatus)
-
-                // Show list regardless of connection status
-                List(selection: $selectedTorrentIds) {
-                    torrentRows
-                }
-                .listStyle(PlainListStyle())
-            }
-            .navigationTitle("Dreams")
-            .navigationBarTitleDisplayMode(.inline)
-            .refreshable {
-                await store.refreshNow()
-            }
-            .searchable(text: $searchText, prompt: "Search torrents")
-            .toolbar {
-                serverToolbarItem
-                actionToolbarItems
-                bottomToolbarItems
-            }
-            .onChange(of: sortProperty) { _, newValue in
-                UserDefaults.standard.sortProperty = newValue
-            }
-            .onChange(of: sortOrder) { _, newValue in
-                UserDefaults.standard.sortOrder = newValue
-            }
-        } detail: {
-            if let selectedTorrent = selectedTorrentsSet.first {
-                TorrentDetail(store: store, torrent: selectedTorrent)
+        Group {
+            if horizontalSizeClass == .compact {
+                compactNavigation
             } else {
-                Text("Select a Dream")
+                regularNavigation
             }
         }
         .onChange(of: store.availableLabels) { _, availableLabels in
@@ -65,7 +32,10 @@ struct iOSContentView: View {
         }
         .onChange(of: store.host?.serverID) { _, _ in
             labelFilter.clear()
-            selectedTorrentIds.removeAll()
+            selectedTorrentID = nil
+        }
+        .onChange(of: store.torrents.map(\.id)) { _, torrentIDs in
+            reconcileSelection(with: torrentIDs)
         }
         .sheet(isPresented: $store.setup, content: {
             iOSServerEditor(store: store, hosts: hosts, host: nil)
@@ -87,6 +57,64 @@ struct iOSContentView: View {
 }
 
 private extension iOSContentView {
+    var compactNavigation: some View {
+        NavigationStack(path: torrentPath) {
+            torrentListScreen
+                .navigationDestination(for: Int.self) { torrentID in
+                    if let torrent = store.torrents.first(where: { $0.id == torrentID }) {
+                        TorrentDetail(store: store, torrent: torrent)
+                    }
+                }
+        }
+    }
+
+    var regularNavigation: some View {
+        NavigationSplitView {
+            torrentListScreen
+        } detail: {
+            if let selectedTorrent {
+                TorrentDetail(store: store, torrent: selectedTorrent)
+            } else {
+                Text("Select a Dream")
+            }
+        }
+    }
+
+    var torrentListScreen: some View {
+        VStack(spacing: 0) {
+            StatsHeaderView(store: store)
+
+            Group {
+                if store.host != nil, store.connectionStatus != .connected {
+                    iOSConnectionBannerView(store: store)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .animation(.default, value: store.connectionStatus)
+
+            // Show list regardless of connection status
+            torrentList
+                .listStyle(PlainListStyle())
+        }
+        .navigationTitle("Dreams")
+        .navigationBarTitleDisplayMode(.inline)
+        .refreshable {
+            await store.refreshNow()
+        }
+        .searchable(text: $searchText, prompt: "Search torrents")
+        .toolbar {
+            serverToolbarItem
+            actionToolbarItems
+            bottomToolbarItems
+        }
+        .onChange(of: sortProperty) { _, newValue in
+            UserDefaults.standard.sortProperty = newValue
+        }
+        .onChange(of: sortOrder) { _, newValue in
+            UserDefaults.standard.sortOrder = newValue
+        }
+    }
+
     var displayedTorrents: [Torrent] {
         filterAndSortTorrents(
             store.torrents,
@@ -100,31 +128,71 @@ private extension iOSContentView {
         )
     }
 
-    var selectedTorrentsSet: Set<Torrent> {
-        Set(selectedTorrentIds.compactMap { id in
-            store.torrents.first { $0.id == id }
-        })
+    var selectedTorrent: Torrent? {
+        guard let selectedTorrentID else { return nil }
+        return store.torrents.first { $0.id == selectedTorrentID }
     }
 
-    var torrentRows: some View {
+    var torrentPath: Binding<[Int]> {
+        Binding(
+            get: { selectedTorrentID.map { [$0] } ?? [] },
+            set: { selectedTorrentID = $0.last }
+        )
+    }
+
+    @ViewBuilder
+    var torrentList: some View {
+        if horizontalSizeClass == .compact {
+            List {
+                compactTorrentRows
+            }
+        } else {
+            List(selection: $selectedTorrentID) {
+                regularTorrentRows
+            }
+        }
+    }
+
+    var compactTorrentRows: some View {
         Group {
             if store.torrents.isEmpty {
-                Text("No dreams available")
-                    .foregroundColor(.gray)
-                    .padding()
+                emptyTorrentList
             } else {
                 ForEach(displayedTorrents, id: \.id) { torrent in
-                    TorrentListRow(
-                        torrent: torrent,
-                        store: store,
-                        selectedTorrents: selectedTorrentsSet,
-                        showContentTypeIcons: showContentTypeIcons
-                    )
-                    .tag(torrent.id)
-                    .listRowSeparator(.visible)
+                    torrentRow(for: torrent, destinationID: torrent.id)
+                        .listRowSeparator(.visible)
                 }
             }
         }
+    }
+
+    var regularTorrentRows: some View {
+        Group {
+            if store.torrents.isEmpty {
+                emptyTorrentList
+            } else {
+                ForEach(displayedTorrents, id: \.id) { torrent in
+                    torrentRow(for: torrent)
+                        .tag(torrent.id)
+                        .listRowSeparator(.visible)
+                }
+            }
+        }
+    }
+
+    var emptyTorrentList: some View {
+        Text("No dreams available")
+            .foregroundColor(.gray)
+            .padding()
+    }
+
+    func torrentRow(for torrent: Torrent, destinationID: Int? = nil) -> some View {
+        iOSTorrentListRow(
+            torrent: torrent,
+            store: store,
+            showContentTypeIcons: showContentTypeIcons,
+            destinationID: destinationID
+        )
     }
 
     var serverToolbarItem: some ToolbarContent {
@@ -144,30 +212,12 @@ private extension iOSContentView {
 
     var actionToolbarItems: some ToolbarContent {
         ToolbarItemGroup(placement: .automatic) {
-            Menu {
-                Button(action: { store.setup.toggle() }, label: {
-                    Label("Add Server", systemImage: "plus")
-                })
-                Button(action: { store.editServers.toggle() }, label: {
-                    Label("Edit Servers", systemImage: "square.and.pencil")
-                })
-                Section("Servers") {
-                    ForEach(hosts, id: \.serverID) { host in
-                        Button {
-                            store.setHost(host: host)
-                        } label: {
-                            Label(
-                                host.name ?? "Unnamed Server",
-                                systemImage: store.host?.serverID == host.serverID
-                                    ? "checkmark.circle.fill"
-                                    : "circle"
-                            )
-                        }
-                    }
-                }
+            Button {
+                store.editServers = true
             } label: {
                 Image(systemName: "server.rack")
             }
+            .accessibilityLabel("Servers")
 
             Button(action: {
                 store.showSettings.toggle()
@@ -183,8 +233,14 @@ private extension iOSContentView {
                 Button {
                     showPrefs.toggle()
                 } label: {
-                    Image(systemName: "slider.horizontal.3")
+                    Label(
+                        "Filter and Sort",
+                        systemImage: hasActiveFilters
+                            ? "line.3.horizontal.decrease.circle.fill"
+                            : "line.3.horizontal.decrease.circle"
+                    )
                 }
+                .accessibilityValue(hasActiveFilters ? "Active" : "Inactive")
                 .popover(isPresented: $showPrefs) {
                     iOSFilterAndSortView(
                         statusFilter: $filterBySelection,
@@ -206,7 +262,7 @@ private extension iOSContentView {
                 Button(action: {
                     store.isShowingAddAlert.toggle()
                 }, label: {
-                    Image(systemName: "plus")
+                    Label("Add Torrent", systemImage: "plus")
                 })
             }
         }
@@ -235,6 +291,15 @@ private extension iOSContentView {
         if reconciledFilter != labelFilter {
             labelFilter = reconciledFilter
         }
+    }
+
+    func reconcileSelection(with torrentIDs: [Int]) {
+        guard let selectedTorrentID, !torrentIDs.contains(selectedTorrentID) else { return }
+        self.selectedTorrentID = nil
+    }
+
+    var hasActiveFilters: Bool {
+        filterBySelection != TorrentStatusCalc.allCases || labelFilter.isActive
     }
 
     var availableLabelCounts: [String: Int] {

--- a/BitDream/Views/iOS/iOSServerList.swift
+++ b/BitDream/Views/iOS/iOSServerList.swift
@@ -33,8 +33,24 @@ struct iOSServerList: View {
     var body: some View {
         NavigationStack {
             List {
-                ForEach(sortedHosts) { host in
-                    row(for: host)
+                if !sortedHosts.isEmpty {
+                    Section {
+                        Picker(selection: activeServerID) {
+                            ForEach(sortedHosts) { host in
+                                Text(host.displayName)
+                                    .tag(Optional(host.serverID))
+                            }
+                        } label: {
+                            Label("Current Server", systemImage: "server.rack")
+                        }
+                        .pickerStyle(.navigationLink)
+                    }
+
+                    Section("Servers") {
+                        ForEach(sortedHosts) { host in
+                            row(for: host)
+                        }
+                    }
                 }
             }
             .navigationTitle("Servers")
@@ -94,6 +110,17 @@ struct iOSServerList: View {
         }
     }
 
+    private var activeServerID: Binding<String?> {
+        Binding(
+            get: { store.host?.serverID },
+            set: { serverID in
+                guard let serverID,
+                      let host = hosts.first(where: { $0.serverID == serverID }) else { return }
+                store.setHost(host: host)
+            }
+        )
+    }
+
     private func row(for host: Host) -> some View {
         let isConnected = host.serverID == store.host?.serverID
 
@@ -103,28 +130,19 @@ struct iOSServerList: View {
             ServerRowLabel(host: host, isConnected: isConnected)
         }
         .tint(.primary)
-        .swipeActions(edge: .leading) {
-            if !isConnected {
-                Button("Connect", systemImage: "bolt.fill") {
-                    store.setHost(host: host)
-                }
-                .tint(.green)
-            }
-        }
-        .swipeActions(edge: .trailing) {
-            Button("Delete", systemImage: "trash", role: .destructive) {
-                promptDelete(host)
-            }
-        }
         .contextMenu {
-            Button("Connect") {
+            Button("Connect", systemImage: "bolt.fill") {
                 store.setHost(host: host)
             }
             .disabled(isConnected)
 
+            Button("Edit", systemImage: "square.and.pencil") {
+                presentedEditor = .edit(host)
+            }
+
             Divider()
 
-            Button("Delete…", role: .destructive) {
+            Button("Delete…", systemImage: "trash", role: .destructive) {
                 promptDelete(host)
             }
         }

--- a/BitDream/Views/iOS/iOSTorrentListRow.swift
+++ b/BitDream/Views/iOS/iOSTorrentListRow.swift
@@ -6,6 +6,7 @@ struct iOSTorrentListRow: View {
     var torrent: Torrent
     var store: TransmissionStore
     var showContentTypeIcons: Bool
+    var destinationID: Int?
 
     @State private var deleteDialog: Bool = false
     @State private var labelDialog: Bool = false
@@ -19,9 +20,7 @@ struct iOSTorrentListRow: View {
     @State private var errorMessage = ""
 
     var body: some View {
-        rowContent
-            .contentShape(Rectangle())
-            .padding(10)
+        listRow
             .swipeActions(edge: .trailing) {
                 swipeActions
             }
@@ -46,6 +45,23 @@ struct iOSTorrentListRow: View {
             .sheet(isPresented: $renameDialog, content: renameSheet)
             .sheet(isPresented: $moveDialog, content: moveSheet)
             .sheet(isPresented: $labelDialog, content: labelSheet)
+    }
+
+    @ViewBuilder
+    private var listRow: some View {
+        if let destinationID {
+            NavigationLink(value: destinationID) {
+                paddedRowContent
+            }
+        } else {
+            paddedRowContent
+        }
+    }
+
+    private var paddedRowContent: some View {
+        rowContent
+            .contentShape(Rectangle())
+            .padding(10)
     }
 
     private var rowContent: some View {


### PR DESCRIPTION
## Summary

- use a native push-navigation flow in compact width while retaining split-view selection in regular width
- share torrent selection across size-class changes and clear stale detail state on server or torrent changes
- keep torrent swipe and context actions attached to the actual list row
- make server management directly accessible with a dedicated Current Server picker
- preserve the existing top-toolbar controls and direct search, filter, add, and settings flows

## Why

The previous compact layout relied on split-view behavior and nested toolbar menus, making iPhone navigation and server management harder to discover. The new structure separates compact and regular-width behavior without changing macOS.
