### PR TITLE
Refresh torrent file details automatically

### DIFF
--- a/BitDream/AppConfig.swift
+++ b/BitDream/AppConfig.swift
@@ -39,6 +39,7 @@ enum AppDefaults {
     static let menuBarSortMode: MenuBarSortMode = .activity
     static let dockShowCompletedBadge: Bool = true
     static let pollInterval: Double = 5.0
+    static let torrentDetailRefreshInterval: TimeInterval = 30.0
     static let ratioDisplayMode: RatioDisplayMode = .cumulative
     static let startupConnectionBehavior: StartupConnectionBehavior = .lastUsed
 }

--- a/BitDream/Transmission/TransmissionReadSnapshots.swift
+++ b/BitDream/Transmission/TransmissionReadSnapshots.swift
@@ -61,22 +61,16 @@ internal extension TransmissionConnection {
     }
 
     func fetchTorrentDetailSnapshot(id: Int) async throws -> TransmissionTorrentDetailSnapshot {
-        async let filesResponse = fetchTorrentFiles(id: id)
-        async let peersResponse = fetchTorrentPeers(id: id)
-        async let piecesResponse = fetchTorrentPieces(id: id)
-
-        let files = try await filesResponse
-        let peers = try await peersResponse
-        let pieces = try await piecesResponse
+        let detail = try await fetchTorrentDetail(id: id)
 
         return TransmissionTorrentDetailSnapshot(
-            files: files.files,
-            fileStats: files.fileStats,
-            peers: peers.peers,
-            peersFrom: peers.peersFrom,
-            pieceCount: pieces.pieceCount,
-            pieceSize: pieces.pieceSize,
-            piecesBitfieldBase64: pieces.pieces
+            files: detail.files,
+            fileStats: detail.fileStats,
+            peers: detail.peers,
+            peersFrom: detail.peersFrom,
+            pieceCount: detail.pieceCount,
+            pieceSize: detail.pieceSize,
+            piecesBitfieldBase64: detail.pieces
         )
     }
 

--- a/BitDream/Transmission/TransmissionTorrentModels.swift
+++ b/BitDream/Transmission/TransmissionTorrentModels.swift
@@ -514,3 +514,19 @@ public struct TorrentPiecesResponseData: Codable, Sendable {
 public struct TorrentPiecesResponseTorrents: Codable, Sendable {
     public let torrents: [TorrentPiecesResponseData]
 }
+
+/// Complete supplemental detail returned for one torrent.
+public struct TorrentDetailResponseData: Codable, Sendable {
+    public let files: [TorrentFile]
+    public let fileStats: [TorrentFileStats]
+    public let peers: [Peer]
+    public let peersFrom: PeersFrom?
+    public let pieceCount: Int
+    public let pieceSize: Int64
+    public let pieces: String
+}
+
+/// Response wrapper for a supplemental torrent detail query.
+public struct TorrentDetailResponseTorrents: Codable, Sendable {
+    public let torrents: [TorrentDetailResponseData]
+}

--- a/BitDream/Transmission/TransmissionTorrents.swift
+++ b/BitDream/Transmission/TransmissionTorrents.swift
@@ -49,6 +49,16 @@ internal enum TransmissionTorrentQuerySpec {
     static func torrentPieces(id: Int) -> TransmissionTorrentDetailQuerySpec {
         TransmissionTorrentDetailQuerySpec(fields: ["pieceCount", "pieceSize", "pieces"], id: id)
     }
+
+    static func torrentDetail(id: Int) -> TransmissionTorrentDetailQuerySpec {
+        TransmissionTorrentDetailQuerySpec(
+            fields: [
+                "files", "fileStats", "peers", "peersFrom",
+                "pieceCount", "pieceSize", "pieces"
+            ],
+            id: id
+        )
+    }
 }
 
 internal extension TransmissionConnection {
@@ -117,6 +127,20 @@ internal extension TransmissionConnection {
             method: "torrent-get",
             arguments: TransmissionTorrentQuerySpec.torrentPieces(id: id).arguments,
             responseType: TorrentPiecesResponseTorrents.self
+        )
+
+        guard let torrent = response.torrents.first else {
+            throw TransmissionError.invalidResponse
+        }
+
+        return torrent
+    }
+
+    func fetchTorrentDetail(id: Int) async throws -> TorrentDetailResponseData {
+        let response = try await sendRequiredArguments(
+            method: "torrent-get",
+            arguments: TransmissionTorrentQuerySpec.torrentDetail(id: id).arguments,
+            responseType: TorrentDetailResponseTorrents.self
         )
 
         guard let torrent = response.torrents.first else {

--- a/BitDream/TransmissionStore.swift
+++ b/BitDream/TransmissionStore.swift
@@ -3,6 +3,11 @@ import Foundation
 import SwiftData
 import OSLog
 
+internal struct TorrentDetailRefreshTrigger: Equatable, Sendable {
+    let connectionGeneration: UUID
+    let revision: UInt64
+}
+
 #if os(macOS)
 enum AddTorrentInitialMode {
     case magnet
@@ -107,7 +112,8 @@ final class TransmissionStore: NSObject, ObservableObject {
 
 
     @Published var sessionConfiguration: TransmissionSessionResponseArguments?
-    @Published private(set) var settingsConnectionGeneration = UUID()
+    @Published private(set) var settingsConnectionGeneration: UUID
+    @Published private(set) var torrentDetailRefreshTrigger: TorrentDetailRefreshTrigger
 
     @Published var pollInterval: Double = AppDefaults.pollInterval // Default poll interval in seconds
     @Published var shouldActivateSearch: Bool = false
@@ -139,16 +145,19 @@ final class TransmissionStore: NSObject, ObservableObject {
     private let resolveConnection: @Sendable (TransmissionConnectionDescriptor) async throws -> TransmissionConnection
     private let snapshotWriter: WidgetSnapshotWriter
     private let sleep: @Sendable (TimeInterval) async throws -> Void
+    private let monotonicTime: @Sendable () -> TimeInterval
+    private let torrentDetailRefreshInterval: TimeInterval
     private let persistVersion: @MainActor @Sendable (String, String) async -> Void
 
     private var activeConnection: ActiveConnection?
     private var activationFailure: ActivationFailure?
-    private var currentConnectionGeneration = UUID()
+    private var currentConnectionGeneration: UUID
     private var activationTask: Task<Void, Never>?
     private var fullRefreshTask: Task<Void, Never>?
     private var pollTask: Task<Void, Never>?
     private var retryTask: Task<Void, Never>?
     private var sessionRefreshTask: Task<Void, Never>?
+    private var nextTorrentDetailRefreshTime: TimeInterval?
 
     private var reconnectBackoff = ExponentialBackoff(base: 1, maxDelay: 30)
     private let logger = Logger(subsystem: AppIdentity.bundleIdentifier, category: "network")
@@ -164,15 +173,26 @@ final class TransmissionStore: NSObject, ObservableObject {
         resolveConnection: (@Sendable (TransmissionConnectionDescriptor) async throws -> TransmissionConnection)? = nil,
         snapshotWriter: WidgetSnapshotWriter = .live,
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void = TransmissionStore.liveSleep,
+        monotonicTime: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+        torrentDetailRefreshInterval: TimeInterval = AppDefaults.torrentDetailRefreshInterval,
         persistVersion: @escaping @MainActor @Sendable (String, String) async -> Void = { serverID, version in
             await HostRepository.shared.persistVersionIfNeeded(serverID: serverID, version: version)
         }
     ) {
+        let initialConnectionGeneration = UUID()
+        self.currentConnectionGeneration = initialConnectionGeneration
+        self.settingsConnectionGeneration = initialConnectionGeneration
+        self.torrentDetailRefreshTrigger = TorrentDetailRefreshTrigger(
+            connectionGeneration: initialConnectionGeneration,
+            revision: 0
+        )
         self.resolveConnection = resolveConnection ?? { descriptor in
             try await connectionFactory.connection(for: descriptor)
         }
         self.snapshotWriter = snapshotWriter
         self.sleep = sleep
+        self.monotonicTime = monotonicTime
+        self.torrentDetailRefreshInterval = max(1, torrentDetailRefreshInterval)
         self.persistVersion = persistVersion
         super.init()
         // Load persisted poll interval if available
@@ -585,6 +605,11 @@ extension TransmissionStore {
     func clearSelectedHost() {
         currentConnectionGeneration = UUID()
         settingsConnectionGeneration = currentConnectionGeneration
+        torrentDetailRefreshTrigger = TorrentDetailRefreshTrigger(
+            connectionGeneration: currentConnectionGeneration,
+            revision: 0
+        )
+        nextTorrentDetailRefreshTime = nil
         cancelRefreshLifecycle()
         resetReconnectState()
 
@@ -668,6 +693,11 @@ extension TransmissionStore {
         let generation = UUID()
         currentConnectionGeneration = generation
         settingsConnectionGeneration = generation
+        torrentDetailRefreshTrigger = TorrentDetailRefreshTrigger(
+            connectionGeneration: generation,
+            revision: 0
+        )
+        nextTorrentDetailRefreshTime = nil
 
         cancelRefreshLifecycle()
         markConnecting()
@@ -747,7 +777,7 @@ extension TransmissionStore {
                 return
             }
 
-            apply(snapshot: snapshot, for: connectionState)
+            applyPollingSnapshot(snapshot, for: connectionState, refreshTorrentDetails: false)
         } catch {
             handleReadError(error, generation: connectionState.generation)
         }
@@ -768,7 +798,7 @@ extension TransmissionStore {
     }
 
     private func apply(snapshot: TransmissionAppRefreshSnapshot, for connectionState: ActiveConnection) {
-        apply(snapshot: snapshot.polling, for: connectionState)
+        applyPollingSnapshot(snapshot.polling, for: connectionState, refreshTorrentDetails: true)
         switch snapshot.sessionSettingsResult {
         case .success(let sessionSettings):
             apply(sessionSettings: sessionSettings, for: connectionState)
@@ -778,9 +808,17 @@ extension TransmissionStore {
         }
     }
 
-    private func apply(snapshot: TransmissionPollingSnapshot, for connectionState: ActiveConnection) {
+    private func applyPollingSnapshot(
+        _ snapshot: TransmissionPollingSnapshot,
+        for connectionState: ActiveConnection,
+        refreshTorrentDetails: Bool
+    ) {
         sessionStats = snapshot.sessionStats
         torrents = snapshot.torrents
+        refreshTorrentDetailsIfNeeded(
+            for: connectionState,
+            force: refreshTorrentDetails
+        )
         snapshotWriter.writeSessionSnapshot(
             connectionState.hostID,
             connectionState.serverName,
@@ -789,6 +827,22 @@ extension TransmissionStore {
             true
         )
         markConnected()
+    }
+
+    private func refreshTorrentDetailsIfNeeded(
+        for connectionState: ActiveConnection,
+        force: Bool
+    ) {
+        let currentTime = monotonicTime()
+        guard force || nextTorrentDetailRefreshTime.map({ currentTime >= $0 }) ?? true else {
+            return
+        }
+
+        torrentDetailRefreshTrigger = TorrentDetailRefreshTrigger(
+            connectionGeneration: connectionState.generation,
+            revision: torrentDetailRefreshTrigger.revision &+ 1
+        )
+        nextTorrentDetailRefreshTime = currentTime + torrentDetailRefreshInterval
     }
 
     private func startPolling(for connectionState: ActiveConnection) {

--- a/BitDream/Views/Shared/TorrentDetail.swift
+++ b/BitDream/Views/Shared/TorrentDetail.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import Combine
 
 struct TorrentDetail: View {
     @ObservedObject var store: TransmissionStore
@@ -26,6 +27,11 @@ internal enum TorrentDetailSupplementalLoadStatus: Sendable, Equatable {
 internal enum TorrentDetailFileStatsMutation: Sendable, Equatable {
     case wanted(Bool)
     case priority(FilePriority)
+}
+
+internal struct TorrentDetailIdentity: Hashable, Sendable {
+    let torrentID: Int
+    let connectionGeneration: UUID
 }
 
 internal struct TorrentDetailSupplementalPayload: Sendable, Equatable {
@@ -132,40 +138,57 @@ internal enum TorrentPiecesSectionState: Equatable {
 }
 
 internal struct TorrentDetailSupplementalState: Sendable {
-    private(set) var activeTorrentID: Int?
+    private(set) var activeIdentity: TorrentDetailIdentity?
     private(set) var activeRequestGeneration: Int = 0
     private(set) var status: TorrentDetailSupplementalLoadStatus = .idle
     private(set) var payload: TorrentDetailSupplementalPayload = .empty
     private(set) var hasLoadedPayload = false
+    private(set) var hasReportedInitialLoadError = false
 
-    func shouldDisplayPayload(for torrentID: Int) -> Bool {
-        activeTorrentID == torrentID && hasLoadedPayload
+    func shouldDisplayPayload(for identity: TorrentDetailIdentity) -> Bool {
+        activeIdentity == identity && hasLoadedPayload
     }
 
-    func visiblePayload(for torrentID: Int) -> TorrentDetailSupplementalPayload {
-        shouldDisplayPayload(for: torrentID) ? payload : .empty
+    func visiblePayload(for identity: TorrentDetailIdentity) -> TorrentDetailSupplementalPayload {
+        shouldDisplayPayload(for: identity) ? payload : .empty
+    }
+
+    func shouldReportInitialLoadError(for identity: TorrentDetailIdentity) -> Bool {
+        guard !shouldDisplayPayload(for: identity) else { return false }
+        return activeIdentity != identity || !hasReportedInitialLoadError
     }
 
     @discardableResult
-    mutating func beginLoading(for torrentID: Int) -> Int {
-        if activeTorrentID != torrentID {
+    mutating func beginLoading(for identity: TorrentDetailIdentity) -> Int {
+        if activeIdentity != identity {
             payload = .empty
             hasLoadedPayload = false
+            hasReportedInitialLoadError = false
         }
 
-        activeTorrentID = torrentID
+        activeIdentity = identity
         activeRequestGeneration += 1
         status = .loading
         return activeRequestGeneration
     }
 
     @discardableResult
+    mutating func markInitialLoadErrorReported(for identity: TorrentDetailIdentity) -> Bool {
+        guard activeIdentity == identity, !hasReportedInitialLoadError else {
+            return false
+        }
+
+        hasReportedInitialLoadError = true
+        return true
+    }
+
+    @discardableResult
     mutating func apply(
         snapshot: TransmissionTorrentDetailSnapshot,
-        for torrentID: Int,
+        for identity: TorrentDetailIdentity,
         generation: Int
     ) -> Bool {
-        guard activeTorrentID == torrentID, activeRequestGeneration == generation else {
+        guard activeIdentity == identity, activeRequestGeneration == generation else {
             return false
         }
 
@@ -176,8 +199,8 @@ internal struct TorrentDetailSupplementalState: Sendable {
     }
 
     @discardableResult
-    mutating func markFailed(for torrentID: Int, generation: Int) -> Bool {
-        guard activeTorrentID == torrentID, activeRequestGeneration == generation else {
+    mutating func markFailed(for identity: TorrentDetailIdentity, generation: Int) -> Bool {
+        guard activeIdentity == identity, activeRequestGeneration == generation else {
             return false
         }
 
@@ -186,8 +209,8 @@ internal struct TorrentDetailSupplementalState: Sendable {
     }
 
     @discardableResult
-    mutating func markCancelled(for torrentID: Int, generation: Int) -> Bool {
-        guard activeTorrentID == torrentID, activeRequestGeneration == generation else {
+    mutating func markCancelled(for identity: TorrentDetailIdentity, generation: Int) -> Bool {
+        guard activeIdentity == identity, activeRequestGeneration == generation else {
             return false
         }
 
@@ -202,10 +225,10 @@ internal struct TorrentDetailSupplementalState: Sendable {
     @discardableResult
     mutating func applyCommittedFileStatsMutation(
         _ mutation: TorrentDetailFileStatsMutation,
-        for torrentID: Int,
+        for identity: TorrentDetailIdentity,
         fileIndices: [Int]
     ) -> Bool {
-        guard activeTorrentID == torrentID, hasLoadedPayload else {
+        guard activeIdentity == identity, hasLoadedPayload else {
             return false
         }
 
@@ -231,6 +254,9 @@ internal final class TorrentDetailSupplementalStore: ObservableObject {
     @Published private(set) var state = TorrentDetailSupplementalState()
     private var managedLoadTask: Task<Void, Never>?
     private var managedLoadGeneration = 0
+    private var loadQueueTail: Task<Void, Never>?
+    private var loadQueueGeneration = 0
+    private var pendingLoadCounts: [TorrentDetailIdentity: Int] = [:]
 
     init(state: TorrentDetailSupplementalState = TorrentDetailSupplementalState()) {
         self.state = state
@@ -238,6 +264,7 @@ internal final class TorrentDetailSupplementalStore: ObservableObject {
 
     deinit {
         managedLoadTask?.cancel()
+        loadQueueTail?.cancel()
     }
 
     var payload: TorrentDetailSupplementalPayload {
@@ -248,51 +275,30 @@ internal final class TorrentDetailSupplementalStore: ObservableObject {
         state.status
     }
 
-    func payload(for torrentID: Int) -> TorrentDetailSupplementalPayload {
-        state.visiblePayload(for: torrentID)
+    func payload(for identity: TorrentDetailIdentity) -> TorrentDetailSupplementalPayload {
+        state.visiblePayload(for: identity)
     }
 
-    func shouldDisplayPayload(for torrentID: Int) -> Bool {
-        state.shouldDisplayPayload(for: torrentID)
+    func shouldDisplayPayload(for identity: TorrentDetailIdentity) -> Bool {
+        state.shouldDisplayPayload(for: identity)
     }
 
     func replaceLoad(
-        for torrentID: Int,
+        for identity: TorrentDetailIdentity,
         using store: TransmissionStore,
         onError: @escaping @MainActor @Sendable (String) -> Void
     ) {
+        guard identity.connectionGeneration == store.torrentDetailRefreshTrigger.connectionGeneration else {
+            return
+        }
+
         managedLoadGeneration += 1
         let generation = managedLoadGeneration
 
         managedLoadTask?.cancel()
-        let requestGeneration = mutateState { state in
-            state.beginLoading(for: torrentID)
-        }
-
-        managedLoadTask = Task { [weak self] in
-            let snapshot = await performStructuredTransmissionOperation(
-                operation: { try await store.loadTorrentDetail(id: torrentID) },
-                onError: { [weak self] message in
-                    guard let self else { return }
-                    guard self.markFailure(for: torrentID, generation: requestGeneration) else {
-                        return
-                    }
-                    onError(message)
-                }
-            )
-
+        managedLoadTask = Task { @MainActor [weak self] in
             guard let self else { return }
-
-            if let snapshot {
-                self.applyManagedSnapshot(
-                    snapshot,
-                    for: torrentID,
-                    requestGeneration: requestGeneration
-                )
-            } else {
-                _ = self.markCancellation(for: torrentID, generation: requestGeneration)
-            }
-
+            await self.load(for: identity, using: store, onError: onError)
             self.clearManagedLoadTask(ifMatching: generation)
         }
     }
@@ -300,50 +306,154 @@ internal final class TorrentDetailSupplementalStore: ObservableObject {
     @discardableResult
     func applyCommittedFileStatsMutation(
         _ mutation: TorrentDetailFileStatsMutation,
-        for torrentID: Int,
+        for identity: TorrentDetailIdentity,
         fileIndices: [Int]
     ) -> Bool {
-        mutateState { $0.applyCommittedFileStatsMutation(mutation, for: torrentID, fileIndices: fileIndices) }
+        mutateState { $0.applyCommittedFileStatsMutation(mutation, for: identity, fileIndices: fileIndices) }
     }
 
     func load(
-        for torrentID: Int,
+        for identity: TorrentDetailIdentity,
         using store: TransmissionStore,
         onError: @escaping @MainActor @Sendable (String) -> Void
     ) async {
+        guard identity.connectionGeneration == store.torrentDetailRefreshTrigger.connectionGeneration else {
+            return
+        }
+
+        let loadTask = enqueueLoad(for: identity, using: store, onError: onError)
+
+        await withTaskCancellationHandler {
+            await loadTask.value
+        } onCancel: {
+            loadTask.cancel()
+        }
+    }
+
+    private func performLoad(
+        for identity: TorrentDetailIdentity,
+        using store: TransmissionStore,
+        onError: @escaping @MainActor @Sendable (String) -> Void
+    ) async {
+        guard identity.connectionGeneration == store.torrentDetailRefreshTrigger.connectionGeneration else {
+            return
+        }
+
         let requestGeneration = mutateState { state in
-            state.beginLoading(for: torrentID)
+            state.beginLoading(for: identity)
         }
 
         guard let snapshot = await performStructuredTransmissionOperation(
-            operation: { try await store.loadTorrentDetail(id: torrentID) },
+            operation: { try await store.loadTorrentDetail(id: identity.torrentID) },
             onError: { [weak self] message in
                 guard let self else { return }
-                guard self.markFailure(for: torrentID, generation: requestGeneration) else {
+                guard self.markFailure(for: identity, generation: requestGeneration) else {
                     return
                 }
                 onError(message)
             }
         ) else {
-            _ = markCancellation(for: torrentID, generation: requestGeneration)
+            _ = markCancellation(for: identity, generation: requestGeneration)
             return
         }
 
         mutateState { state in
             _ = state.apply(
                 snapshot: snapshot,
-                for: torrentID,
+                for: identity,
                 generation: requestGeneration
             )
         }
     }
 
+    private func enqueueLoad(
+        for identity: TorrentDetailIdentity,
+        using store: TransmissionStore,
+        onError: @escaping @MainActor @Sendable (String) -> Void
+    ) -> Task<Void, Never> {
+        let predecessor = loadQueueTail
+        loadQueueGeneration += 1
+        let generation = loadQueueGeneration
+        pendingLoadCounts[identity, default: 0] += 1
+
+        let task = Task { @MainActor [weak self] in
+            await predecessor?.value
+            guard let self else { return }
+            defer {
+                self.finishPendingLoad(for: identity)
+                self.clearLoadQueueTail(ifMatching: generation)
+            }
+            guard !Task.isCancelled else { return }
+
+            await self.performLoad(for: identity, using: store, onError: onError)
+        }
+
+        loadQueueTail = task
+        return task
+    }
+
+    func refresh(
+        for identity: TorrentDetailIdentity,
+        using store: TransmissionStore,
+        onInitialLoadError: @escaping @MainActor @Sendable (String) -> Void
+    ) async {
+        await load(for: identity, using: store) { message in
+            guard self.state.shouldReportInitialLoadError(for: identity) else {
+                return
+            }
+            let didMarkReported = self.mutateState {
+                $0.markInitialLoadErrorReported(for: identity)
+            }
+            guard didMarkReported else { return }
+            onInitialLoadError(message)
+        }
+    }
+
+    func observeRefreshes(
+        for identity: TorrentDetailIdentity,
+        using store: TransmissionStore,
+        onInitialLoadError: @escaping @MainActor @Sendable (String) -> Void
+    ) async {
+        var processedRevision: UInt64?
+
+        for await publishedTrigger in store.$torrentDetailRefreshTrigger.values {
+            guard !Task.isCancelled else { return }
+            guard publishedTrigger.connectionGeneration == identity.connectionGeneration else { return }
+            guard processedRevision.map({ publishedTrigger.revision > $0 }) ?? true else {
+                continue
+            }
+
+            var requestedRevision = publishedTrigger.revision
+
+            while true {
+                await refresh(
+                    for: identity,
+                    using: store,
+                    onInitialLoadError: onInitialLoadError
+                )
+
+                guard !Task.isCancelled else { return }
+                processedRevision = requestedRevision
+
+                let latestTrigger = store.torrentDetailRefreshTrigger
+                guard latestTrigger.connectionGeneration == identity.connectionGeneration else { return }
+                guard latestTrigger.revision > requestedRevision else { break }
+
+                requestedRevision = latestTrigger.revision
+            }
+        }
+    }
+
     func loadIfIdle(
-        for torrentID: Int,
+        for identity: TorrentDetailIdentity,
         using store: TransmissionStore,
         onError: @escaping @MainActor @Sendable (String) -> Void
     ) async {
-        guard !state.shouldDisplayPayload(for: torrentID) else {
+        guard pendingLoadCounts[identity, default: 0] == 0 else {
+            return
+        }
+
+        guard !state.shouldDisplayPayload(for: identity) else {
             return
         }
 
@@ -351,79 +461,29 @@ internal final class TorrentDetailSupplementalStore: ObservableObject {
             return
         }
 
-        await load(for: torrentID, using: store, onError: onError)
+        await load(for: identity, using: store, onError: onError)
     }
 
-    func load(
-        for torrentID: Int,
-        using store: TransmissionStore,
-        showingError: Binding<Bool>,
-        errorMessage: Binding<String>
-    ) async {
-        await load(
-            for: torrentID,
-            using: store,
-            onError: makeTransmissionBindingErrorHandler(
-                isPresented: showingError,
-                message: errorMessage
-            )
-        )
-    }
-
-    func replaceLoad(
-        for torrentID: Int,
-        using store: TransmissionStore,
-        showingError: Binding<Bool>,
-        errorMessage: Binding<String>
-    ) {
-        replaceLoad(
-            for: torrentID,
-            using: store,
-            onError: makeTransmissionBindingErrorHandler(
-                isPresented: showingError,
-                message: errorMessage
-            )
-        )
-    }
-
-    func loadIfIdle(
-        for torrentID: Int,
-        using store: TransmissionStore,
-        showingError: Binding<Bool>,
-        errorMessage: Binding<String>
-    ) async {
-        await loadIfIdle(
-            for: torrentID,
-            using: store,
-            onError: makeTransmissionBindingErrorHandler(
-                isPresented: showingError,
-                message: errorMessage
-            )
-        )
-    }
-
-    @discardableResult
-    private func markFailure(for torrentID: Int, generation: Int) -> Bool {
-        mutateState { $0.markFailed(for: torrentID, generation: generation) }
-    }
-
-    @discardableResult
-    private func markCancellation(for torrentID: Int, generation: Int) -> Bool {
-        mutateState { $0.markCancelled(for: torrentID, generation: generation) }
-    }
-
-    private func applyManagedSnapshot(
-        _ snapshot: TransmissionTorrentDetailSnapshot,
-        for torrentID: Int,
-        requestGeneration: Int
-    ) {
-        mutateState { state in
-            _ = state.apply(
-                snapshot: snapshot,
-                for: torrentID,
-                generation: requestGeneration
-            )
+    private func finishPendingLoad(for identity: TorrentDetailIdentity) {
+        guard let count = pendingLoadCounts[identity] else {
+            return
         }
+
+        if count == 1 {
+            pendingLoadCounts.removeValue(forKey: identity)
+        } else {
+            pendingLoadCounts[identity] = count - 1
+        }
+    }
+
+    @discardableResult
+    private func markFailure(for identity: TorrentDetailIdentity, generation: Int) -> Bool {
+        mutateState { $0.markFailed(for: identity, generation: generation) }
+    }
+
+    @discardableResult
+    private func markCancellation(for identity: TorrentDetailIdentity, generation: Int) -> Bool {
+        mutateState { $0.markCancelled(for: identity, generation: generation) }
     }
 
     private func clearManagedLoadTask(ifMatching generation: Int) {
@@ -432,6 +492,14 @@ internal final class TorrentDetailSupplementalStore: ObservableObject {
         }
 
         managedLoadTask = nil
+    }
+
+    private func clearLoadQueueTail(ifMatching generation: Int) {
+        guard loadQueueGeneration == generation else {
+            return
+        }
+
+        loadQueueTail = nil
     }
 
     @discardableResult

--- a/BitDream/Views/Shared/TorrentDetailSupplementalStore+Bindings.swift
+++ b/BitDream/Views/Shared/TorrentDetailSupplementalStore+Bindings.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+@MainActor
+extension TorrentDetailSupplementalStore {
+    func load(
+        for identity: TorrentDetailIdentity,
+        using store: TransmissionStore,
+        showingError: Binding<Bool>,
+        errorMessage: Binding<String>
+    ) async {
+        await load(
+            for: identity,
+            using: store,
+            onError: makeTransmissionBindingErrorHandler(
+                isPresented: showingError,
+                message: errorMessage
+            )
+        )
+    }
+
+    func refresh(
+        for identity: TorrentDetailIdentity,
+        using store: TransmissionStore,
+        showingInitialLoadError: Binding<Bool>,
+        errorMessage: Binding<String>
+    ) async {
+        await refresh(
+            for: identity,
+            using: store,
+            onInitialLoadError: makeTransmissionBindingErrorHandler(
+                isPresented: showingInitialLoadError,
+                message: errorMessage
+            )
+        )
+    }
+
+    func observeRefreshes(
+        for identity: TorrentDetailIdentity,
+        using store: TransmissionStore,
+        showingInitialLoadError: Binding<Bool>,
+        errorMessage: Binding<String>
+    ) async {
+        await observeRefreshes(
+            for: identity,
+            using: store,
+            onInitialLoadError: makeTransmissionBindingErrorHandler(
+                isPresented: showingInitialLoadError,
+                message: errorMessage
+            )
+        )
+    }
+
+    func replaceLoad(
+        for identity: TorrentDetailIdentity,
+        using store: TransmissionStore,
+        showingError: Binding<Bool>,
+        errorMessage: Binding<String>
+    ) {
+        replaceLoad(
+            for: identity,
+            using: store,
+            onError: makeTransmissionBindingErrorHandler(
+                isPresented: showingError,
+                message: errorMessage
+            )
+        )
+    }
+
+    func loadIfIdle(
+        for identity: TorrentDetailIdentity,
+        using store: TransmissionStore,
+        showingError: Binding<Bool>,
+        errorMessage: Binding<String>
+    ) async {
+        await loadIfIdle(
+            for: identity,
+            using: store,
+            onError: makeTransmissionBindingErrorHandler(
+                isPresented: showingError,
+                message: errorMessage
+            )
+        )
+    }
+}

--- a/BitDream/Views/iOS/iOSTorrentDetail.swift
+++ b/BitDream/Views/iOS/iOSTorrentDetail.swift
@@ -21,16 +21,23 @@ struct iOSTorrentDetail: View {
     @State private var errorMessage = ""
 
     private var supplementalPayload: TorrentDetailSupplementalPayload {
-        supplementalStore.payload(for: torrent.id)
+        supplementalStore.payload(for: supplementalIdentity)
     }
 
     private var shouldDisplaySupplementalPayload: Bool {
-        supplementalStore.shouldDisplayPayload(for: torrent.id)
+        supplementalStore.shouldDisplayPayload(for: supplementalIdentity)
     }
 
-    private func replaceSupplementalLoad(for torrentID: Int) {
+    private var supplementalIdentity: TorrentDetailIdentity {
+        TorrentDetailIdentity(
+            torrentID: torrent.id,
+            connectionGeneration: store.torrentDetailRefreshTrigger.connectionGeneration
+        )
+    }
+
+    private func replaceSupplementalLoad() {
         supplementalStore.replaceLoad(
-            for: torrentID,
+            for: supplementalIdentity,
             using: store,
             showingError: $showingError,
             errorMessage: $errorMessage
@@ -54,11 +61,16 @@ struct iOSTorrentDetail: View {
             peersDestination: peersDestination,
             onDelete: { showingDeleteConfirmation = true },
             onRetryPiecesLoad: {
-                replaceSupplementalLoad(for: torrent.id)
+                replaceSupplementalLoad()
             }
         )
-        .onChange(of: torrent.id, initial: true) { _, newTorrentID in
-            replaceSupplementalLoad(for: newTorrentID)
+        .task(id: supplementalIdentity) {
+            await supplementalStore.observeRefreshes(
+                for: supplementalIdentity,
+                using: store,
+                showingInitialLoadError: $showingError,
+                errorMessage: $errorMessage
+            )
         }
         .toolbar {
             detailToolbar
@@ -181,7 +193,7 @@ struct iOSTorrentDetail: View {
     ) {
         supplementalStore.applyCommittedFileStatsMutation(
             mutation,
-            for: torrent.id,
+            for: supplementalIdentity,
             fileIndices: fileIndices
         )
     }
@@ -209,8 +221,8 @@ struct iOSTorrentDetail: View {
                 loadingMessage: "Fetching the latest files for this torrent.",
                 unavailableTitle: "Files Unavailable",
                 unavailableMessage: "The latest file details could not be loaded.",
-                onLoadIfIdle: { await supplementalStore.loadIfIdle(for: torrent.id, using: store, showingError: $showingError, errorMessage: $errorMessage) },
-                onRetry: { replaceSupplementalLoad(for: torrent.id) }
+                onLoadIfIdle: { await supplementalStore.loadIfIdle(for: supplementalIdentity, using: store, showingError: $showingError, errorMessage: $errorMessage) },
+                onRetry: { replaceSupplementalLoad() }
             )
             .navigationTitle("Files")
             .navigationBarTitleDisplayMode(.inline)
@@ -226,7 +238,7 @@ struct iOSTorrentDetail: View {
                 store: store,
                 peers: supplementalPayload.peers,
                 peersFrom: supplementalPayload.peersFrom,
-                onRefresh: { await supplementalStore.load(for: torrent.id, using: store, showingError: $showingError, errorMessage: $errorMessage) },
+                onRefresh: { await supplementalStore.load(for: supplementalIdentity, using: store, showingError: $showingError, errorMessage: $errorMessage) },
                 onDone: { /* no-op in push */ }
             )
             .navigationBarTitleDisplayMode(.inline)
@@ -237,8 +249,8 @@ struct iOSTorrentDetail: View {
                 loadingMessage: "Fetching the latest peers for this torrent.",
                 unavailableTitle: "Peers Unavailable",
                 unavailableMessage: "The latest peer details could not be loaded.",
-                onLoadIfIdle: { await supplementalStore.loadIfIdle(for: torrent.id, using: store, showingError: $showingError, errorMessage: $errorMessage) },
-                onRetry: { replaceSupplementalLoad(for: torrent.id) }
+                onLoadIfIdle: { await supplementalStore.loadIfIdle(for: supplementalIdentity, using: store, showingError: $showingError, errorMessage: $errorMessage) },
+                onRetry: { replaceSupplementalLoad() }
             )
             .navigationTitle("Peers")
             .navigationBarTitleDisplayMode(.inline)

--- a/BitDream/Views/macOS/macOSTorrentDetail.swift
+++ b/BitDream/Views/macOS/macOSTorrentDetail.swift
@@ -16,11 +16,18 @@ struct macOSTorrentDetail: View {
     @State private var errorMessage = ""
 
     private var supplementalPayload: TorrentDetailSupplementalPayload {
-        supplementalStore.payload(for: torrent.id)
+        supplementalStore.payload(for: supplementalIdentity)
     }
 
     private var shouldDisplaySupplementalPayload: Bool {
-        supplementalStore.shouldDisplayPayload(for: torrent.id)
+        supplementalStore.shouldDisplayPayload(for: supplementalIdentity)
+    }
+
+    private var supplementalIdentity: TorrentDetailIdentity {
+        TorrentDetailIdentity(
+            torrentID: torrent.id,
+            connectionGeneration: store.torrentDetailRefreshTrigger.connectionGeneration
+        )
     }
 
     var body: some View {
@@ -79,8 +86,13 @@ struct macOSTorrentDetail: View {
             peersSheetContent
                 .frame(minWidth: 1000, minHeight: 700)
         }
-        .task(id: torrent.id) {
-            await supplementalStore.load(for: torrent.id, using: store, showingError: $showingError, errorMessage: $errorMessage)
+        .task(id: supplementalIdentity) {
+            await supplementalStore.observeRefreshes(
+                for: supplementalIdentity,
+                using: store,
+                showingInitialLoadError: $showingError,
+                errorMessage: $errorMessage
+            )
         }
         .toolbar {
             // Use shared toolbar
@@ -109,7 +121,7 @@ struct macOSTorrentDetail: View {
     ) {
         supplementalStore.applyCommittedFileStatsMutation(
             mutation,
-            for: torrent.id,
+            for: supplementalIdentity,
             fileIndices: fileIndices
         )
     }
@@ -154,8 +166,8 @@ struct macOSTorrentDetail: View {
                 loadingMessage: "Fetching the latest files for this torrent.",
                 unavailableTitle: "Files Unavailable",
                 unavailableMessage: "The latest file details could not be loaded.",
-                onLoadIfIdle: { await supplementalStore.loadIfIdle(for: torrent.id, using: store, showingError: $showingError, errorMessage: $errorMessage) },
-                onRetry: { supplementalStore.replaceLoad(for: torrent.id, using: store, showingError: $showingError, errorMessage: $errorMessage) }
+                onLoadIfIdle: { await supplementalStore.loadIfIdle(for: supplementalIdentity, using: store, showingError: $showingError, errorMessage: $errorMessage) },
+                onRetry: { supplementalStore.replaceLoad(for: supplementalIdentity, using: store, showingError: $showingError, errorMessage: $errorMessage) }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
@@ -170,7 +182,7 @@ struct macOSTorrentDetail: View {
                 store: store,
                 peers: supplementalPayload.peers,
                 peersFrom: supplementalPayload.peersFrom,
-                onRefresh: { await supplementalStore.load(for: torrent.id, using: store, showingError: $showingError, errorMessage: $errorMessage) },
+                onRefresh: { await supplementalStore.load(for: supplementalIdentity, using: store, showingError: $showingError, errorMessage: $errorMessage) },
                 onDone: { isShowingPeersSheet = false }
             )
         } else {
@@ -180,8 +192,8 @@ struct macOSTorrentDetail: View {
                 loadingMessage: "Fetching the latest peers for this torrent.",
                 unavailableTitle: "Peers Unavailable",
                 unavailableMessage: "The latest peer details could not be loaded.",
-                onLoadIfIdle: { await supplementalStore.loadIfIdle(for: torrent.id, using: store, showingError: $showingError, errorMessage: $errorMessage) },
-                onRetry: { supplementalStore.replaceLoad(for: torrent.id, using: store, showingError: $showingError, errorMessage: $errorMessage) }
+                onLoadIfIdle: { await supplementalStore.loadIfIdle(for: supplementalIdentity, using: store, showingError: $showingError, errorMessage: $errorMessage) },
+                onRetry: { supplementalStore.replaceLoad(for: supplementalIdentity, using: store, showingError: $showingError, errorMessage: $errorMessage) }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }

--- a/BitDreamTests/Transmission/Connection/TransmissionConnectionQueryTests.swift
+++ b/BitDreamTests/Transmission/Connection/TransmissionConnectionQueryTests.swift
@@ -161,8 +161,6 @@ final class TransmissionConnectionQueryTests: XCTestCase {
     func testFetchTorrentDetailSnapshotUsesNamedQueriesAndDecodesResponse() async throws {
         let sender = MethodQueueSender(stepsByMethod: [
             "torrent-get": [
-                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
-                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
                 .http(statusCode: 200, body: makeTorrentDetailSuccessBody())
             ]
         ])
@@ -181,18 +179,16 @@ final class TransmissionConnectionQueryTests: XCTestCase {
         XCTAssertEqual(snapshot.piecesBitfieldBase64, "Zm9v")
 
         let requests = await sender.capturedRequests()
-        XCTAssertEqual(requests.count, 3)
-        let fields = try requests.map(capturedRequestFields)
-        XCTAssertTrue(fields.contains(TransmissionTorrentQuerySpec.torrentFiles(id: 42).fields))
-        XCTAssertTrue(fields.contains(TransmissionTorrentQuerySpec.torrentPeers(id: 42).fields))
-        XCTAssertTrue(fields.contains(TransmissionTorrentQuerySpec.torrentPieces(id: 42).fields))
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(
+            try capturedRequestFields(requests[0]),
+            TransmissionTorrentQuerySpec.torrentDetail(id: 42).fields
+        )
     }
 
     func testFetchTorrentDetailSnapshotPropagatesErrors() async throws {
         let sender = MethodQueueSender(stepsByMethod: [
             "torrent-get": [
-                .http(statusCode: 200, body: #"{"result":"server busy","arguments":{}}"#),
-                .http(statusCode: 200, body: #"{"result":"server busy","arguments":{}}"#),
                 .http(statusCode: 200, body: #"{"result":"server busy","arguments":{}}"#)
             ]
         ])

--- a/BitDreamTests/Transmission/TransmissionTestSupport.swift
+++ b/BitDreamTests/Transmission/TransmissionTestSupport.swift
@@ -2,6 +2,18 @@ import Foundation
 import XCTest
 @testable import BitDream
 
+let testTorrentDetailConnectionGeneration = UUID()
+
+func makeTestTorrentDetailIdentity(
+    _ torrentID: Int,
+    connectionGeneration: UUID = testTorrentDetailConnectionGeneration
+) -> TorrentDetailIdentity {
+    TorrentDetailIdentity(
+        torrentID: torrentID,
+        connectionGeneration: connectionGeneration
+    )
+}
+
 let successStatsBody = """
 {
   "arguments": {

--- a/BitDreamTests/TransmissionStore/TransmissionStoreFullRefreshDegradationTests.swift
+++ b/BitDreamTests/TransmissionStore/TransmissionStoreFullRefreshDegradationTests.swift
@@ -4,6 +4,38 @@ import XCTest
 
 @MainActor
 final class TransmissionStoreFullRefreshTests: XCTestCase {
+    func testSuccessfulRefreshAdvancesTorrentDetailRefreshTrigger() async throws {
+        let sender = MethodQueueSender(stepsByMethod: [
+            "session-stats": [
+                .http(statusCode: 200, body: successStatsBody),
+                .http(statusCode: 200, body: successStatsBody)
+            ],
+            "torrent-get": [
+                .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json")),
+                .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json"))
+            ],
+            "session-get": [
+                .http(statusCode: 200, body: try sessionSettingsBody(downloadDir: "/downloads", version: "4.0.0")),
+                .http(statusCode: 200, body: try sessionSettingsBody(downloadDir: "/downloads", version: "4.0.0"))
+            ]
+        ])
+        let store = makeStore(sender: sender)
+        let initialTrigger = store.torrentDetailRefreshTrigger
+
+        store.setHost(host: makeHost(serverID: "server-1", server: "example.com"))
+        let didConnect = await waitUntil { store.connectionStatus == .connected }
+        XCTAssertTrue(didConnect)
+        let connectedTrigger = store.torrentDetailRefreshTrigger
+
+        await store.refreshNow()
+        let refreshedTrigger = store.torrentDetailRefreshTrigger
+
+        XCTAssertNotEqual(connectedTrigger.connectionGeneration, initialTrigger.connectionGeneration)
+        XCTAssertEqual(connectedTrigger.revision, 1)
+        XCTAssertEqual(refreshedTrigger.connectionGeneration, connectedTrigger.connectionGeneration)
+        XCTAssertEqual(refreshedTrigger.revision, 2)
+    }
+
     func testInitialFullRefreshConnectsWhenSessionSettingsFail() async throws {
         let sender = MethodQueueSender(stepsByMethod: [
             "session-stats": [

--- a/BitDreamTests/TransmissionStore/TransmissionStoreRefreshLifecycleTests.swift
+++ b/BitDreamTests/TransmissionStore/TransmissionStoreRefreshLifecycleTests.swift
@@ -43,6 +43,45 @@ final class TransmissionStoreRefreshLifecycleTests: XCTestCase {
         XCTAssertEqual(recorder.sessionSnapshotCount, 1)
     }
 
+    func testPollingRefreshesTorrentDetailsOnlyWhenDetailCadenceIsDue() async throws {
+        let torrentSummary = try loadTransmissionFixture(named: "torrent-get.response.json")
+        let sender = MethodQueueSender(stepsByMethod: [
+            "session-stats": Array(
+                repeating: .http(statusCode: 200, body: successStatsBody),
+                count: 3
+            ),
+            "torrent-get": Array(
+                repeating: .http(statusCode: 200, body: torrentSummary),
+                count: 3
+            ),
+            "session-get": [
+                .http(
+                    statusCode: 200,
+                    body: try sessionSettingsBody(downloadDir: "/downloads", version: "4.0.0")
+                )
+            ]
+        ])
+        let sleepController = ScriptedSleep(steps: [.immediate, .immediate, .suspend])
+        let monotonicTime = ScriptedMonotonicTime(values: [0, 10, 30])
+        let store = makeStore(
+            sender: sender,
+            sleepController: sleepController,
+            monotonicTime: monotonicTime.next,
+            torrentDetailRefreshInterval: 30
+        )
+
+        store.setHost(host: makeHost(serverID: "server-1", server: "example.com"))
+
+        let didCompleteTwoPolls = await waitUntil {
+            let requestCount = await sender.capturedRequests().count
+            let sleepCount = await sleepController.callCount()
+            return requestCount == 7 && sleepCount == 3
+        }
+        XCTAssertTrue(didCompleteTwoPolls)
+        XCTAssertEqual(store.torrentDetailRefreshTrigger.revision, 2)
+        XCTAssertEqual(monotonicTime.callCount, 3)
+    }
+
     func testReconnectOnSameHostIsNotANoOp() async throws {
         let sender = MethodQueueSender(stepsByMethod: [
             "session-stats": [
@@ -337,7 +376,11 @@ private extension TransmissionStoreRefreshLifecycleTests {
     func makeStore(
         sender: some TransmissionRPCRequestSending,
         sleepController: ScriptedSleep,
-        recorder: TestWidgetSnapshotRecorder = TestWidgetSnapshotRecorder()
+        recorder: TestWidgetSnapshotRecorder = TestWidgetSnapshotRecorder(),
+        monotonicTime: @escaping @Sendable () -> TimeInterval = {
+            ProcessInfo.processInfo.systemUptime
+        },
+        torrentDetailRefreshInterval: TimeInterval = AppDefaults.torrentDetailRefreshInterval
     ) -> TransmissionStore {
         let factory = TransmissionConnectionFactory(
             transport: TransmissionTransport(sender: sender),
@@ -357,6 +400,8 @@ private extension TransmissionStoreRefreshLifecycleTests {
             sleep: { seconds in
                 try await sleepController.sleep(seconds: seconds)
             },
+            monotonicTime: monotonicTime,
+            torrentDetailRefreshInterval: torrentDetailRefreshInterval,
             persistVersion: { _, _ in }
         )
     }
@@ -387,6 +432,31 @@ private extension TransmissionStoreRefreshLifecycleTests {
             await Task.yield()
         }
         return false
+    }
+}
+
+private final class ScriptedMonotonicTime: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [TimeInterval]
+    private var calls = 0
+
+    var callCount: Int {
+        lock.withLock { calls }
+    }
+
+    init(values: [TimeInterval]) {
+        precondition(!values.isEmpty)
+        self.values = values
+    }
+
+    func next() -> TimeInterval {
+        lock.withLock {
+            calls += 1
+            guard values.count > 1 else {
+                return values[0]
+            }
+            return values.removeFirst()
+        }
     }
 }
 

--- a/BitDreamTests/TransmissionStore/TransmissionStoreTorrentOperationTests.swift
+++ b/BitDreamTests/TransmissionStore/TransmissionStoreTorrentOperationTests.swift
@@ -132,9 +132,7 @@ final class TransmissionStoreTorrentOperationTests: XCTestCase {
                 ],
                 "torrent-get": [
                     .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json")),
-                    .blocked(id: "old-detail", statusCode: 200, body: makeTorrentDetailSuccessBody()),
-                    .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
-                    .http(statusCode: 200, body: makeTorrentDetailSuccessBody())
+                    .blocked(id: "old-detail", statusCode: 200, body: makeTorrentDetailSuccessBody())
                 ],
                 "session-get": [
                     .http(statusCode: 200, body: try sessionSettingsBody(downloadDir: "/downloads/old", version: "4.0.0"))

--- a/BitDreamTests/Views/TorrentDetailRefreshLoopTests.swift
+++ b/BitDreamTests/Views/TorrentDetailRefreshLoopTests.swift
@@ -1,0 +1,245 @@
+import XCTest
+@testable import BitDream
+
+@MainActor
+final class TorrentDetailRefreshLoopTests: XCTestCase {
+    func testActiveLoadFinishesAndPollingRevisionsCoalesce() async throws {
+        let scenario = try makeScenario()
+        var errors: [String] = []
+
+        scenario.transmissionStore.setHost(
+            host: makeHost(serverID: "server-1", server: "example.com")
+        )
+        let didConnect = await waitUntil {
+            scenario.transmissionStore.connectionStatus == .connected
+        }
+        XCTAssertTrue(didConnect)
+        let identity = makeIdentity(for: scenario.transmissionStore)
+
+        let observationTask = makeObservationTask(
+            for: scenario,
+            identity: identity
+        ) { errors.append($0) }
+        let didStartInitialDetail = await waitUntil {
+            await self.torrentGetRequestCount(sender: scenario.sender) == 2
+        }
+        XCTAssertTrue(didStartInitialDetail)
+
+        let explicitLoadTask = makeExplicitLoadTask(
+            for: scenario,
+            identity: identity
+        ) { errors.append($0) }
+        await Task.yield()
+        let requestCountWithExplicitLoadQueued = await torrentGetRequestCount(sender: scenario.sender)
+        XCTAssertEqual(requestCountWithExplicitLoadQueued, 2)
+
+        await scenario.transmissionStore.refreshNow()
+        await scenario.transmissionStore.refreshNow()
+
+        let requestCountWhileBlocked = await torrentGetRequestCount(sender: scenario.sender)
+        XCTAssertEqual(requestCountWhileBlocked, 4)
+        XCTAssertEqual(scenario.supplementalStore.status, .loading)
+        XCTAssertFalse(scenario.supplementalStore.shouldDisplayPayload(for: identity))
+
+        await scenario.sender.resume(id: "initial-detail")
+        await explicitLoadTask.value
+        let didFinishCatchUpRefresh = await waitUntil {
+            scenario.supplementalStore.status == .failed
+        }
+        XCTAssertTrue(didFinishCatchUpRefresh)
+        let finalRequestCount = await torrentGetRequestCount(sender: scenario.sender)
+        XCTAssertEqual(finalRequestCount, 6)
+        XCTAssertEqual(
+            scenario.supplementalStore.payload(for: identity).files.first?.bytesCompleted,
+            2
+        )
+        XCTAssertTrue(scenario.supplementalStore.shouldDisplayPayload(for: identity))
+        XCTAssertEqual(errors, [])
+
+        observationTask.cancel()
+        await observationTask.value
+    }
+
+    func testQueuedRefreshRechecksInitialErrorStateWhenItFails() async throws {
+        let scenario = try makeQueuedFailureScenario()
+        var errors: [String] = []
+
+        scenario.transmissionStore.setHost(
+            host: makeHost(serverID: "server-1", server: "example.com")
+        )
+        let didConnect = await waitUntil {
+            scenario.transmissionStore.connectionStatus == .connected
+        }
+        XCTAssertTrue(didConnect)
+        let identity = makeIdentity(for: scenario.transmissionStore)
+
+        let initialRefresh = makeRefreshTask(
+            for: scenario,
+            identity: identity
+        ) { errors.append($0) }
+        let didStartInitialDetail = await waitUntil {
+            await self.torrentGetRequestCount(sender: scenario.sender) == 2
+        }
+        XCTAssertTrue(didStartInitialDetail)
+
+        let queuedRefresh = makeRefreshTask(
+            for: scenario,
+            identity: identity
+        ) { errors.append($0) }
+        await Task.yield()
+        await scenario.sender.resume(id: "initial-detail")
+        await initialRefresh.value
+        await queuedRefresh.value
+
+        XCTAssertEqual(scenario.supplementalStore.status, .failed)
+        XCTAssertEqual(
+            scenario.supplementalStore.payload(for: identity).files.first?.bytesCompleted,
+            1
+        )
+        XCTAssertTrue(scenario.supplementalStore.shouldDisplayPayload(for: identity))
+        XCTAssertEqual(errors, [])
+    }
+}
+
+@MainActor
+private extension TorrentDetailRefreshLoopTests {
+    struct Scenario {
+        let sender: HostMethodScriptedSender
+        let transmissionStore: TransmissionStore
+        let supplementalStore: TorrentDetailSupplementalStore
+    }
+
+    func makeScenario() throws -> Scenario {
+        let sender = HostMethodScriptedSender(stepsByHostAndMethod: [
+            "example.com": [
+                "session-stats": threeSuccessfulSessionStatsSteps(),
+                "torrent-get": try torrentGetSteps(),
+                "session-get": try threeSuccessfulSessionSettingsSteps()
+            ]
+        ])
+        return Scenario(
+            sender: sender,
+            transmissionStore: makeStore(sender: sender),
+            supplementalStore: TorrentDetailSupplementalStore()
+        )
+    }
+
+    func makeQueuedFailureScenario() throws -> Scenario {
+        let summary = try loadTransmissionFixture(named: "torrent-get.response.json")
+        let sender = HostMethodScriptedSender(stepsByHostAndMethod: [
+            "example.com": [
+                "session-stats": [.http(statusCode: 200, body: successStatsBody)],
+                "torrent-get": [
+                    .http(statusCode: 200, body: summary),
+                    .blocked(
+                        id: "initial-detail",
+                        statusCode: 200,
+                        body: makeTorrentDetailSuccessBody(bytesCompleted: 1)
+                    ),
+                    .http(statusCode: 200, body: detailFailureBody())
+                ],
+                "session-get": [
+                    .http(
+                        statusCode: 200,
+                        body: try sessionSettingsBody(downloadDir: "/downloads", version: "4.0.0")
+                    )
+                ]
+            ]
+        ])
+        return Scenario(
+            sender: sender,
+            transmissionStore: makeStore(sender: sender),
+            supplementalStore: TorrentDetailSupplementalStore()
+        )
+    }
+
+    func makeIdentity(for store: TransmissionStore) -> TorrentDetailIdentity {
+        TorrentDetailIdentity(
+            torrentID: 42,
+            connectionGeneration: store.torrentDetailRefreshTrigger.connectionGeneration
+        )
+    }
+
+    func makeObservationTask(
+        for scenario: Scenario,
+        identity: TorrentDetailIdentity,
+        onError: @escaping @MainActor @Sendable (String) -> Void
+    ) -> Task<Void, Never> {
+        return Task { @MainActor in
+            await scenario.supplementalStore.observeRefreshes(
+                for: identity,
+                using: scenario.transmissionStore,
+                onInitialLoadError: onError
+            )
+        }
+    }
+
+    func makeExplicitLoadTask(
+        for scenario: Scenario,
+        identity: TorrentDetailIdentity,
+        onError: @escaping @MainActor @Sendable (String) -> Void
+    ) -> Task<Void, Never> {
+        Task { @MainActor in
+            await scenario.supplementalStore.load(
+                for: identity,
+                using: scenario.transmissionStore,
+                onError: onError
+            )
+        }
+    }
+
+    func makeRefreshTask(
+        for scenario: Scenario,
+        identity: TorrentDetailIdentity,
+        onError: @escaping @MainActor @Sendable (String) -> Void
+    ) -> Task<Void, Never> {
+        Task { @MainActor in
+            await scenario.supplementalStore.refresh(
+                for: identity,
+                using: scenario.transmissionStore,
+                onInitialLoadError: onError
+            )
+        }
+    }
+
+    func threeSuccessfulSessionStatsSteps() -> [HostMethodScriptedSender.Step] {
+        Array(repeating: .http(statusCode: 200, body: successStatsBody), count: 3)
+    }
+
+    func threeSuccessfulSessionSettingsSteps() throws -> [HostMethodScriptedSender.Step] {
+        let body = try sessionSettingsBody(downloadDir: "/downloads", version: "4.0.0")
+        return Array(repeating: .http(statusCode: 200, body: body), count: 3)
+    }
+
+    func torrentGetSteps() throws -> [HostMethodScriptedSender.Step] {
+        let summary = try loadTransmissionFixture(named: "torrent-get.response.json")
+        return [
+            .http(statusCode: 200, body: summary),
+            .blocked(
+                id: "initial-detail",
+                statusCode: 200,
+                body: makeTorrentDetailSuccessBody(bytesCompleted: 1)
+            ),
+            .http(statusCode: 200, body: summary),
+            .http(statusCode: 200, body: summary),
+            .http(statusCode: 200, body: makeTorrentDetailSuccessBody(bytesCompleted: 2)),
+            .http(statusCode: 200, body: detailFailureBody())
+        ]
+    }
+
+    func detailFailureBody() -> String {
+        """
+        {
+          "arguments": {},
+          "result": "background refresh failed"
+        }
+        """
+    }
+
+    func torrentGetRequestCount(sender: HostMethodScriptedSender) async -> Int {
+        await sender.capturedRequests().count { request in
+            let urlRequest = request.asURLRequest()
+            return (try? requestMethod(from: urlRequest)) == "torrent-get"
+        }
+    }
+}

--- a/BitDreamTests/Views/TorrentDetailSupplementalStateTests.swift
+++ b/BitDreamTests/Views/TorrentDetailSupplementalStateTests.swift
@@ -4,13 +4,14 @@ import XCTest
 final class TorrentDetailSupplementalStateTests: XCTestCase {
     func testBeginLoadingClearsPayloadForNewTorrentAndTracksActiveTorrent() {
         var state = TorrentDetailSupplementalState()
-        let generation = state.beginLoading(for: 42)
+        let generation = state.beginLoading(for: makeTestTorrentDetailIdentity(42))
 
-        XCTAssertEqual(state.activeTorrentID, 42)
+        XCTAssertEqual(state.activeIdentity, makeTestTorrentDetailIdentity(42))
         XCTAssertEqual(state.activeRequestGeneration, generation)
         XCTAssertEqual(state.status, .loading)
         XCTAssertEqual(state.payload, .empty)
-        XCTAssertFalse(state.shouldDisplayPayload(for: 42))
+        XCTAssertFalse(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(42)))
+        XCTAssertFalse(state.hasReportedInitialLoadError)
     }
 
     func testApplySnapshotPopulatesPayloadAndPieceCount() {
@@ -20,8 +21,8 @@ final class TorrentDetailSupplementalStateTests: XCTestCase {
             piecesBitfieldBase64: Data([0b1010_0000]).base64EncodedString()
         )
 
-        let generation = state.beginLoading(for: 7)
-        let didApply = state.apply(snapshot: snapshot, for: 7, generation: generation)
+        let generation = state.beginLoading(for: makeTestTorrentDetailIdentity(7))
+        let didApply = state.apply(snapshot: snapshot, for: makeTestTorrentDetailIdentity(7), generation: generation)
 
         XCTAssertTrue(didApply)
         XCTAssertEqual(state.status, .loaded)
@@ -31,7 +32,7 @@ final class TorrentDetailSupplementalStateTests: XCTestCase {
         XCTAssertEqual(state.payload.peersFrom, snapshot.peersFrom)
         XCTAssertEqual(state.payload.pieceCount, 3)
         XCTAssertEqual(state.payload.piecesHaveCount, 2)
-        XCTAssertTrue(state.shouldDisplayPayload(for: 7))
+        XCTAssertTrue(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(7)))
     }
 
     func testApplySnapshotIgnoresStaleRequest() {
@@ -39,92 +40,92 @@ final class TorrentDetailSupplementalStateTests: XCTestCase {
         let oldSnapshot = makeSnapshot(fileName: "old-file")
         let newSnapshot = makeSnapshot(fileName: "new-file")
 
-        let oldGeneration = state.beginLoading(for: 1)
-        XCTAssertTrue(state.apply(snapshot: oldSnapshot, for: 1, generation: oldGeneration))
+        let oldGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(1))
+        XCTAssertTrue(state.apply(snapshot: oldSnapshot, for: makeTestTorrentDetailIdentity(1), generation: oldGeneration))
 
-        let newGeneration = state.beginLoading(for: 2)
+        let newGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(2))
         let didApplyStaleSnapshot = state.apply(
             snapshot: oldSnapshot,
-            for: 1,
+            for: makeTestTorrentDetailIdentity(1),
             generation: oldGeneration
         )
         let didApplyCurrentSnapshot = state.apply(
             snapshot: newSnapshot,
-            for: 2,
+            for: makeTestTorrentDetailIdentity(2),
             generation: newGeneration
         )
 
         XCTAssertFalse(didApplyStaleSnapshot)
         XCTAssertTrue(didApplyCurrentSnapshot)
-        XCTAssertEqual(state.activeTorrentID, 2)
+        XCTAssertEqual(state.activeIdentity, makeTestTorrentDetailIdentity(2))
         XCTAssertEqual(state.activeRequestGeneration, newGeneration)
         XCTAssertEqual(state.status, .loaded)
         XCTAssertEqual(state.payload.files.map(\.name), ["new-file"])
-        XCTAssertTrue(state.shouldDisplayPayload(for: 2))
+        XCTAssertTrue(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(2)))
     }
 
     func testBeginLoadingForSameTorrentPreservesLoadedPayload() {
         var state = TorrentDetailSupplementalState()
         let snapshot = makeSnapshot()
 
-        let firstGeneration = state.beginLoading(for: 11)
-        XCTAssertTrue(state.apply(snapshot: snapshot, for: 11, generation: firstGeneration))
+        let firstGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(11))
+        XCTAssertTrue(state.apply(snapshot: snapshot, for: makeTestTorrentDetailIdentity(11), generation: firstGeneration))
 
-        let secondGeneration = state.beginLoading(for: 11)
+        let secondGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(11))
 
-        XCTAssertEqual(state.activeTorrentID, 11)
+        XCTAssertEqual(state.activeIdentity, makeTestTorrentDetailIdentity(11))
         XCTAssertEqual(state.activeRequestGeneration, secondGeneration)
         XCTAssertNotEqual(firstGeneration, secondGeneration)
         XCTAssertEqual(state.status, .loading)
         XCTAssertEqual(state.payload.files, snapshot.files)
-        XCTAssertTrue(state.shouldDisplayPayload(for: 11))
+        XCTAssertTrue(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(11)))
     }
 
     func testBeginLoadingForDifferentTorrentClearsLoadedPayload() {
         var state = TorrentDetailSupplementalState()
         let snapshot = makeSnapshot()
 
-        let firstGeneration = state.beginLoading(for: 11)
-        XCTAssertTrue(state.apply(snapshot: snapshot, for: 11, generation: firstGeneration))
+        let firstGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(11))
+        XCTAssertTrue(state.apply(snapshot: snapshot, for: makeTestTorrentDetailIdentity(11), generation: firstGeneration))
 
-        let secondGeneration = state.beginLoading(for: 12)
+        let secondGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(12))
 
-        XCTAssertEqual(state.activeTorrentID, 12)
+        XCTAssertEqual(state.activeIdentity, makeTestTorrentDetailIdentity(12))
         XCTAssertEqual(state.activeRequestGeneration, secondGeneration)
         XCTAssertEqual(state.status, .loading)
         XCTAssertEqual(state.payload, .empty)
-        XCTAssertFalse(state.shouldDisplayPayload(for: 12))
+        XCTAssertFalse(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(12)))
     }
 
     func testMarkFailedPreservesPayloadForActiveRequest() {
         var state = TorrentDetailSupplementalState()
         let snapshot = makeSnapshot()
 
-        let generation = state.beginLoading(for: 11)
-        XCTAssertTrue(state.apply(snapshot: snapshot, for: 11, generation: generation))
+        let generation = state.beginLoading(for: makeTestTorrentDetailIdentity(11))
+        XCTAssertTrue(state.apply(snapshot: snapshot, for: makeTestTorrentDetailIdentity(11), generation: generation))
 
-        let didMarkFailure = state.markFailed(for: 11, generation: generation)
+        let didMarkFailure = state.markFailed(for: makeTestTorrentDetailIdentity(11), generation: generation)
 
         XCTAssertTrue(didMarkFailure)
         XCTAssertEqual(state.status, .failed)
         XCTAssertEqual(state.payload.files, snapshot.files)
-        XCTAssertTrue(state.shouldDisplayPayload(for: 11))
+        XCTAssertTrue(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(11)))
     }
 
     func testMarkFailedIgnoresStaleRequest() {
         var state = TorrentDetailSupplementalState()
 
-        let staleGeneration = state.beginLoading(for: 3)
-        let currentGeneration = state.beginLoading(for: 4)
+        let staleGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(3))
+        let currentGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(4))
 
-        let didMarkFailure = state.markFailed(for: 3, generation: staleGeneration)
+        let didMarkFailure = state.markFailed(for: makeTestTorrentDetailIdentity(3), generation: staleGeneration)
 
         XCTAssertFalse(didMarkFailure)
-        XCTAssertEqual(state.activeTorrentID, 4)
+        XCTAssertEqual(state.activeIdentity, makeTestTorrentDetailIdentity(4))
         XCTAssertEqual(state.activeRequestGeneration, currentGeneration)
         XCTAssertEqual(state.status, .loading)
         XCTAssertEqual(state.payload, .empty)
-        XCTAssertFalse(state.shouldDisplayPayload(for: 4))
+        XCTAssertFalse(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(4)))
     }
 
     func testApplySnapshotRecoversAfterFailureWhileRetainingPayload() {
@@ -132,17 +133,17 @@ final class TorrentDetailSupplementalStateTests: XCTestCase {
         let oldSnapshot = makeSnapshot(fileName: "old-file")
         let newSnapshot = makeSnapshot(fileName: "new-file")
 
-        let firstGeneration = state.beginLoading(for: 7)
-        XCTAssertTrue(state.apply(snapshot: oldSnapshot, for: 7, generation: firstGeneration))
-        XCTAssertTrue(state.markFailed(for: 7, generation: firstGeneration))
-        let secondGeneration = state.beginLoading(for: 7)
+        let firstGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(7))
+        XCTAssertTrue(state.apply(snapshot: oldSnapshot, for: makeTestTorrentDetailIdentity(7), generation: firstGeneration))
+        XCTAssertTrue(state.markFailed(for: makeTestTorrentDetailIdentity(7), generation: firstGeneration))
+        let secondGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(7))
 
-        let didApply = state.apply(snapshot: newSnapshot, for: 7, generation: secondGeneration)
+        let didApply = state.apply(snapshot: newSnapshot, for: makeTestTorrentDetailIdentity(7), generation: secondGeneration)
 
         XCTAssertTrue(didApply)
         XCTAssertEqual(state.status, .loaded)
         XCTAssertEqual(state.payload.files.map(\.name), ["new-file"])
-        XCTAssertTrue(state.shouldDisplayPayload(for: 7))
+        XCTAssertTrue(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(7)))
     }
 
     func testApplySnapshotIgnoresOlderGenerationForSameTorrent() {
@@ -150,111 +151,111 @@ final class TorrentDetailSupplementalStateTests: XCTestCase {
         let olderSnapshot = makeSnapshot(fileName: "older-file")
         let newerSnapshot = makeSnapshot(fileName: "newer-file")
 
-        let olderGeneration = state.beginLoading(for: 9)
-        let newerGeneration = state.beginLoading(for: 9)
+        let olderGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(9))
+        let newerGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(9))
 
         let didApplyOlderSnapshot = state.apply(
             snapshot: olderSnapshot,
-            for: 9,
+            for: makeTestTorrentDetailIdentity(9),
             generation: olderGeneration
         )
         let didApplyNewerSnapshot = state.apply(
             snapshot: newerSnapshot,
-            for: 9,
+            for: makeTestTorrentDetailIdentity(9),
             generation: newerGeneration
         )
 
         XCTAssertFalse(didApplyOlderSnapshot)
         XCTAssertTrue(didApplyNewerSnapshot)
-        XCTAssertEqual(state.activeTorrentID, 9)
+        XCTAssertEqual(state.activeIdentity, makeTestTorrentDetailIdentity(9))
         XCTAssertEqual(state.activeRequestGeneration, newerGeneration)
         XCTAssertEqual(state.status, .loaded)
         XCTAssertEqual(state.payload.files.map(\.name), ["newer-file"])
-        XCTAssertTrue(state.shouldDisplayPayload(for: 9))
+        XCTAssertTrue(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(9)))
     }
 
     func testMarkFailedIgnoresOlderGenerationForSameTorrent() {
         var state = TorrentDetailSupplementalState()
         let snapshot = makeSnapshot(fileName: "retained-file")
 
-        let initialGeneration = state.beginLoading(for: 13)
-        XCTAssertTrue(state.apply(snapshot: snapshot, for: 13, generation: initialGeneration))
+        let initialGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(13))
+        XCTAssertTrue(state.apply(snapshot: snapshot, for: makeTestTorrentDetailIdentity(13), generation: initialGeneration))
 
-        let staleGeneration = state.beginLoading(for: 13)
-        let currentGeneration = state.beginLoading(for: 13)
+        let staleGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(13))
+        let currentGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(13))
 
-        let didMarkStaleFailure = state.markFailed(for: 13, generation: staleGeneration)
+        let didMarkStaleFailure = state.markFailed(for: makeTestTorrentDetailIdentity(13), generation: staleGeneration)
 
         XCTAssertFalse(didMarkStaleFailure)
-        XCTAssertEqual(state.activeTorrentID, 13)
+        XCTAssertEqual(state.activeIdentity, makeTestTorrentDetailIdentity(13))
         XCTAssertEqual(state.activeRequestGeneration, currentGeneration)
         XCTAssertEqual(state.status, .loading)
         XCTAssertEqual(state.payload.files.map(\.name), ["retained-file"])
-        XCTAssertTrue(state.shouldDisplayPayload(for: 13))
+        XCTAssertTrue(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(13)))
     }
 
     func testMarkCancelledRestoresIdleStateWhenNoPayloadExists() {
         var state = TorrentDetailSupplementalState()
 
-        let generation = state.beginLoading(for: 21)
-        let didMarkCancellation = state.markCancelled(for: 21, generation: generation)
+        let generation = state.beginLoading(for: makeTestTorrentDetailIdentity(21))
+        let didMarkCancellation = state.markCancelled(for: makeTestTorrentDetailIdentity(21), generation: generation)
 
         XCTAssertTrue(didMarkCancellation)
-        XCTAssertEqual(state.activeTorrentID, 21)
+        XCTAssertEqual(state.activeIdentity, makeTestTorrentDetailIdentity(21))
         XCTAssertEqual(state.activeRequestGeneration, generation)
         XCTAssertEqual(state.status, .idle)
         XCTAssertEqual(state.payload, .empty)
-        XCTAssertFalse(state.shouldDisplayPayload(for: 21))
+        XCTAssertFalse(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(21)))
     }
 
     func testMarkCancelledRestoresLoadedStateWhenPayloadExists() {
         var state = TorrentDetailSupplementalState()
         let snapshot = makeSnapshot(fileName: "retained-file")
 
-        let firstGeneration = state.beginLoading(for: 22)
-        XCTAssertTrue(state.apply(snapshot: snapshot, for: 22, generation: firstGeneration))
-        let secondGeneration = state.beginLoading(for: 22)
+        let firstGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(22))
+        XCTAssertTrue(state.apply(snapshot: snapshot, for: makeTestTorrentDetailIdentity(22), generation: firstGeneration))
+        let secondGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(22))
 
-        let didMarkCancellation = state.markCancelled(for: 22, generation: secondGeneration)
+        let didMarkCancellation = state.markCancelled(for: makeTestTorrentDetailIdentity(22), generation: secondGeneration)
 
         XCTAssertTrue(didMarkCancellation)
-        XCTAssertEqual(state.activeTorrentID, 22)
+        XCTAssertEqual(state.activeIdentity, makeTestTorrentDetailIdentity(22))
         XCTAssertEqual(state.activeRequestGeneration, secondGeneration)
         XCTAssertEqual(state.status, .loaded)
         XCTAssertEqual(state.payload.files.map(\.name), ["retained-file"])
-        XCTAssertTrue(state.shouldDisplayPayload(for: 22))
+        XCTAssertTrue(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(22)))
     }
 
     func testMarkCancelledIgnoresOlderGenerationForSameTorrent() {
         var state = TorrentDetailSupplementalState()
         let snapshot = makeSnapshot(fileName: "retained-file")
 
-        let firstGeneration = state.beginLoading(for: 23)
-        XCTAssertTrue(state.apply(snapshot: snapshot, for: 23, generation: firstGeneration))
-        let staleGeneration = state.beginLoading(for: 23)
-        let currentGeneration = state.beginLoading(for: 23)
+        let firstGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(23))
+        XCTAssertTrue(state.apply(snapshot: snapshot, for: makeTestTorrentDetailIdentity(23), generation: firstGeneration))
+        let staleGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(23))
+        let currentGeneration = state.beginLoading(for: makeTestTorrentDetailIdentity(23))
 
-        let didMarkCancellation = state.markCancelled(for: 23, generation: staleGeneration)
+        let didMarkCancellation = state.markCancelled(for: makeTestTorrentDetailIdentity(23), generation: staleGeneration)
 
         XCTAssertFalse(didMarkCancellation)
-        XCTAssertEqual(state.activeTorrentID, 23)
+        XCTAssertEqual(state.activeIdentity, makeTestTorrentDetailIdentity(23))
         XCTAssertEqual(state.activeRequestGeneration, currentGeneration)
         XCTAssertEqual(state.status, .loading)
         XCTAssertEqual(state.payload.files.map(\.name), ["retained-file"])
-        XCTAssertTrue(state.shouldDisplayPayload(for: 23))
+        XCTAssertTrue(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(23)))
     }
 
     func testShouldDisplayPayloadRequiresMatchingActiveTorrentID() {
         var state = TorrentDetailSupplementalState()
         let snapshot = makeSnapshot(fileName: "retained-file")
 
-        let generation = state.beginLoading(for: 24)
-        XCTAssertTrue(state.apply(snapshot: snapshot, for: 24, generation: generation))
+        let generation = state.beginLoading(for: makeTestTorrentDetailIdentity(24))
+        XCTAssertTrue(state.apply(snapshot: snapshot, for: makeTestTorrentDetailIdentity(24), generation: generation))
 
-        XCTAssertTrue(state.shouldDisplayPayload(for: 24))
-        XCTAssertFalse(state.shouldDisplayPayload(for: 25))
-        XCTAssertEqual(state.visiblePayload(for: 24).files.map(\.name), ["retained-file"])
-        XCTAssertEqual(state.visiblePayload(for: 25), .empty)
+        XCTAssertTrue(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(24)))
+        XCTAssertFalse(state.shouldDisplayPayload(for: makeTestTorrentDetailIdentity(25)))
+        XCTAssertEqual(state.visiblePayload(for: makeTestTorrentDetailIdentity(24)).files.map(\.name), ["retained-file"])
+        XCTAssertEqual(state.visiblePayload(for: makeTestTorrentDetailIdentity(25)), .empty)
     }
 
     func testPiecesSectionStateResolvesLoadingWhenPayloadIsUnavailable() {
@@ -313,6 +314,106 @@ final class TorrentDetailSupplementalStateTests: XCTestCase {
         )
 
         XCTAssertEqual(state, .content(payload))
+    }
+}
+
+final class TorrentDetailIdentityStateTests: XCTestCase {
+    func testBeginLoadingForNewConnectionClearsPayloadForSameTorrent() {
+        var state = TorrentDetailSupplementalState()
+        let oldIdentity = makeTestTorrentDetailIdentity(42, connectionGeneration: UUID())
+        let newIdentity = makeTestTorrentDetailIdentity(42, connectionGeneration: UUID())
+        let oldGeneration = state.beginLoading(for: oldIdentity)
+
+        XCTAssertTrue(state.apply(snapshot: makeSnapshot(), for: oldIdentity, generation: oldGeneration))
+        XCTAssertTrue(state.markInitialLoadErrorReported(for: oldIdentity))
+
+        let newGeneration = state.beginLoading(for: newIdentity)
+
+        XCTAssertEqual(state.activeIdentity, newIdentity)
+        XCTAssertEqual(state.activeRequestGeneration, newGeneration)
+        XCTAssertEqual(state.status, .loading)
+        XCTAssertEqual(state.payload, .empty)
+        XCTAssertFalse(state.shouldDisplayPayload(for: oldIdentity))
+        XCTAssertFalse(state.shouldDisplayPayload(for: newIdentity))
+        XCTAssertFalse(state.hasReportedInitialLoadError)
+        XCTAssertTrue(state.shouldReportInitialLoadError(for: newIdentity))
+    }
+
+    func testLateResponseFromPreviousConnectionIsIgnoredForSameTorrent() {
+        var state = TorrentDetailSupplementalState()
+        let oldIdentity = makeTestTorrentDetailIdentity(42, connectionGeneration: UUID())
+        let newIdentity = makeTestTorrentDetailIdentity(42, connectionGeneration: UUID())
+        let oldGeneration = state.beginLoading(for: oldIdentity)
+        let newGeneration = state.beginLoading(for: newIdentity)
+
+        let didApplyOldResponse = state.apply(
+            snapshot: makeSnapshot(fileName: "old-connection-file"),
+            for: oldIdentity,
+            generation: oldGeneration
+        )
+        let didApplyNewResponse = state.apply(
+            snapshot: makeSnapshot(fileName: "new-connection-file"),
+            for: newIdentity,
+            generation: newGeneration
+        )
+
+        XCTAssertFalse(didApplyOldResponse)
+        XCTAssertTrue(didApplyNewResponse)
+        XCTAssertEqual(state.payload.files.map(\.name), ["new-connection-file"])
+        XCTAssertTrue(state.shouldDisplayPayload(for: newIdentity))
+    }
+
+    func testCommittedMutationFromPreviousConnectionIsIgnoredForSameTorrent() {
+        var state = TorrentDetailSupplementalState()
+        let oldIdentity = makeTestTorrentDetailIdentity(42, connectionGeneration: UUID())
+        let newIdentity = makeTestTorrentDetailIdentity(42, connectionGeneration: UUID())
+        let generation = state.beginLoading(for: newIdentity)
+        XCTAssertTrue(state.apply(snapshot: makeSnapshot(), for: newIdentity, generation: generation))
+
+        let didApply = state.applyCommittedFileStatsMutation(
+            .wanted(false),
+            for: oldIdentity,
+            fileIndices: [0]
+        )
+
+        XCTAssertFalse(didApply)
+        XCTAssertTrue(state.payload.fileStats[0].wanted)
+    }
+}
+
+final class TorrentDetailSupplementalErrorStateTests: XCTestCase {
+    func testInitialLoadErrorIsReportedOnlyOnceForActiveTorrent() {
+        var state = TorrentDetailSupplementalState()
+
+        XCTAssertTrue(state.shouldReportInitialLoadError(for: makeTestTorrentDetailIdentity(11)))
+        _ = state.beginLoading(for: makeTestTorrentDetailIdentity(11))
+        XCTAssertTrue(state.shouldReportInitialLoadError(for: makeTestTorrentDetailIdentity(11)))
+        XCTAssertTrue(state.markInitialLoadErrorReported(for: makeTestTorrentDetailIdentity(11)))
+
+        XCTAssertFalse(state.shouldReportInitialLoadError(for: makeTestTorrentDetailIdentity(11)))
+        XCTAssertTrue(state.shouldReportInitialLoadError(for: makeTestTorrentDetailIdentity(12)))
+    }
+
+    func testTaskIdentityIgnoresPollingRevisionButTracksTorrentAndConnection() {
+        let connectionGeneration = UUID()
+        let initialIdentity = TorrentDetailIdentity(
+            torrentID: 42,
+            connectionGeneration: connectionGeneration
+        )
+        let sameIdentityAfterPolling = TorrentDetailIdentity(
+            torrentID: 42,
+            connectionGeneration: connectionGeneration
+        )
+
+        XCTAssertEqual(initialIdentity, sameIdentityAfterPolling)
+        XCTAssertNotEqual(
+            initialIdentity,
+            TorrentDetailIdentity(torrentID: 43, connectionGeneration: connectionGeneration)
+        )
+        XCTAssertNotEqual(
+            initialIdentity,
+            TorrentDetailIdentity(torrentID: 42, connectionGeneration: UUID())
+        )
     }
 }
 

--- a/BitDreamTests/Views/TorrentDetailSupplementalStoreTests.swift
+++ b/BitDreamTests/Views/TorrentDetailSupplementalStoreTests.swift
@@ -3,15 +3,13 @@ import XCTest
 
 @MainActor
 final class TorrentDetailSupplementalStoreTests: XCTestCase {
-    func testLoadIfIdleLoadsOnlyOnceFromIdle() async throws {
+    func testConcurrentLoadIfIdleCallsLoadOnlyOnceFromIdle() async throws {
         let sender = MethodQueueSender(stepsByMethod: [
             "session-stats": [
                 .http(statusCode: 200, body: successStatsBody)
             ],
             "torrent-get": [
                 .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json")),
-                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
-                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
                 .http(statusCode: 200, body: makeTorrentDetailSuccessBody())
             ],
             "session-get": [
@@ -25,15 +23,28 @@ final class TorrentDetailSupplementalStoreTests: XCTestCase {
         transmissionStore.setHost(host: makeHost(serverID: "server-1", server: "example.com"))
         let didConnect = await waitUntil { transmissionStore.connectionStatus == .connected }
         XCTAssertTrue(didConnect)
+        let identity = makeIdentity(torrentID: 42, store: transmissionStore)
 
-        await supplementalStore.loadIfIdle(for: 42, using: transmissionStore) { errors.append($0) }
-        await supplementalStore.loadIfIdle(for: 42, using: transmissionStore) { errors.append($0) }
+        let firstLoad = Task { @MainActor in
+            await supplementalStore.loadIfIdle(
+                for: identity,
+                using: transmissionStore
+            ) { errors.append($0) }
+        }
+        let secondLoad = Task { @MainActor in
+            await supplementalStore.loadIfIdle(
+                for: identity,
+                using: transmissionStore
+            ) { errors.append($0) }
+        }
+        await firstLoad.value
+        await secondLoad.value
 
         let methods = try await sender.capturedRequests().map { try requestMethod(from: $0.asURLRequest()) }
-        XCTAssertEqual(methods.filter { $0 == "torrent-get" }.count, 4)
+        XCTAssertEqual(methods.filter { $0 == "torrent-get" }.count, 2)
         XCTAssertEqual(errors, [])
         XCTAssertEqual(supplementalStore.status, .loaded)
-        XCTAssertTrue(supplementalStore.shouldDisplayPayload(for: 42))
+        XCTAssertTrue(supplementalStore.shouldDisplayPayload(for: identity))
     }
 
     func testLoadIfIdleDoesNotRetryFromFailedStateWithoutPayload() async throws {
@@ -43,8 +54,6 @@ final class TorrentDetailSupplementalStoreTests: XCTestCase {
             ],
             "torrent-get": [
                 .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json")),
-                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
-                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
                 .http(statusCode: 200, body: rpcFailureBody(result: "detail load failed"))
             ],
             "session-get": [
@@ -58,16 +67,17 @@ final class TorrentDetailSupplementalStoreTests: XCTestCase {
         transmissionStore.setHost(host: makeHost(serverID: "server-1", server: "example.com"))
         let didConnect = await waitUntil { transmissionStore.connectionStatus == .connected }
         XCTAssertTrue(didConnect)
+        let identity = makeIdentity(torrentID: 42, store: transmissionStore)
 
-        await supplementalStore.loadIfIdle(for: 42, using: transmissionStore) { errors.append($0) }
-        await supplementalStore.loadIfIdle(for: 42, using: transmissionStore) { errors.append($0) }
+        await supplementalStore.loadIfIdle(for: identity, using: transmissionStore) { errors.append($0) }
+        await supplementalStore.loadIfIdle(for: identity, using: transmissionStore) { errors.append($0) }
 
         let methods = try await sender.capturedRequests().map { try requestMethod(from: $0.asURLRequest()) }
-        XCTAssertEqual(methods.filter { $0 == "torrent-get" }.count, 4)
+        XCTAssertEqual(methods.filter { $0 == "torrent-get" }.count, 2)
         XCTAssertEqual(errors, ["detail load failed"])
         XCTAssertEqual(supplementalStore.status, .failed)
-        XCTAssertEqual(supplementalStore.payload(for: 42), .empty)
-        XCTAssertFalse(supplementalStore.shouldDisplayPayload(for: 42))
+        XCTAssertEqual(supplementalStore.payload(for: identity), .empty)
+        XCTAssertFalse(supplementalStore.shouldDisplayPayload(for: identity))
     }
 
     func testExplicitLoadRetriesAfterFailedIdleLoadAndRecovers() async throws {
@@ -77,11 +87,7 @@ final class TorrentDetailSupplementalStoreTests: XCTestCase {
             ],
             "torrent-get": [
                 .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json")),
-                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
-                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
                 .http(statusCode: 200, body: rpcFailureBody(result: "detail load failed")),
-                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
-                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
                 .http(statusCode: 200, body: makeTorrentDetailSuccessBody())
             ],
             "session-get": [
@@ -95,18 +101,116 @@ final class TorrentDetailSupplementalStoreTests: XCTestCase {
         transmissionStore.setHost(host: makeHost(serverID: "server-1", server: "example.com"))
         let didConnect = await waitUntil { transmissionStore.connectionStatus == .connected }
         XCTAssertTrue(didConnect)
+        let identity = makeIdentity(torrentID: 42, store: transmissionStore)
 
-        await supplementalStore.loadIfIdle(for: 42, using: transmissionStore) { errors.append($0) }
+        await supplementalStore.loadIfIdle(for: identity, using: transmissionStore) { errors.append($0) }
         XCTAssertEqual(supplementalStore.status, .failed)
 
-        await supplementalStore.load(for: 42, using: transmissionStore) { errors.append($0) }
+        await supplementalStore.load(for: identity, using: transmissionStore) { errors.append($0) }
 
         let methods = try await sender.capturedRequests().map { try requestMethod(from: $0.asURLRequest()) }
-        XCTAssertEqual(methods.filter { $0 == "torrent-get" }.count, 7)
+        XCTAssertEqual(methods.filter { $0 == "torrent-get" }.count, 3)
         XCTAssertEqual(errors, ["detail load failed"])
         XCTAssertEqual(supplementalStore.status, .loaded)
-        XCTAssertTrue(supplementalStore.shouldDisplayPayload(for: 42))
-        XCTAssertEqual(supplementalStore.payload(for: 42).files.map(\.name), ["Ubuntu.iso"])
+        XCTAssertTrue(supplementalStore.shouldDisplayPayload(for: identity))
+        XCTAssertEqual(supplementalStore.payload(for: identity).files.map(\.name), ["Ubuntu.iso"])
+    }
+
+    func testBackgroundRefreshFailureRetainsPayloadWithoutReportingError() async throws {
+        let sender = MethodQueueSender(stepsByMethod: [
+            "session-stats": [
+                .http(statusCode: 200, body: successStatsBody)
+            ],
+            "torrent-get": [
+                .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json")),
+                .http(statusCode: 200, body: makeTorrentDetailSuccessBody()),
+                .http(statusCode: 200, body: rpcFailureBody(result: "background refresh failed"))
+            ],
+            "session-get": [
+                .http(statusCode: 200, body: try sessionSettingsBody(downloadDir: "/downloads/initial", version: "4.0.0"))
+            ]
+        ])
+        let transmissionStore = makeStore(sender: sender)
+        let supplementalStore = TorrentDetailSupplementalStore()
+        var errors: [String] = []
+
+        transmissionStore.setHost(host: makeHost(serverID: "server-1", server: "example.com"))
+        let didConnect = await waitUntil { transmissionStore.connectionStatus == .connected }
+        XCTAssertTrue(didConnect)
+        let identity = makeIdentity(torrentID: 42, store: transmissionStore)
+
+        await supplementalStore.refresh(for: identity, using: transmissionStore) { errors.append($0) }
+        let loadedPayload = supplementalStore.payload(for: identity)
+        await supplementalStore.refresh(for: identity, using: transmissionStore) { errors.append($0) }
+
+        XCTAssertEqual(errors, [])
+        XCTAssertEqual(supplementalStore.status, .failed)
+        XCTAssertEqual(supplementalStore.payload(for: identity), loadedPayload)
+        XCTAssertTrue(supplementalStore.shouldDisplayPayload(for: identity))
+    }
+
+    func testRepeatedInitialRefreshFailuresReportOnlyFirstError() async throws {
+        let sender = MethodQueueSender(stepsByMethod: [
+            "session-stats": [
+                .http(statusCode: 200, body: successStatsBody)
+            ],
+            "torrent-get": [
+                .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json")),
+                .http(statusCode: 200, body: rpcFailureBody(result: "first failure")),
+                .http(statusCode: 200, body: rpcFailureBody(result: "second failure"))
+            ],
+            "session-get": [
+                .http(statusCode: 200, body: try sessionSettingsBody(downloadDir: "/downloads/initial", version: "4.0.0"))
+            ]
+        ])
+        let transmissionStore = makeStore(sender: sender)
+        let supplementalStore = TorrentDetailSupplementalStore()
+        var errors: [String] = []
+
+        transmissionStore.setHost(host: makeHost(serverID: "server-1", server: "example.com"))
+        let didConnect = await waitUntil { transmissionStore.connectionStatus == .connected }
+        XCTAssertTrue(didConnect)
+        let identity = makeIdentity(torrentID: 42, store: transmissionStore)
+
+        await supplementalStore.refresh(for: identity, using: transmissionStore) { errors.append($0) }
+        await supplementalStore.refresh(for: identity, using: transmissionStore) { errors.append($0) }
+
+        XCTAssertEqual(errors, ["first failure"])
+        XCTAssertEqual(supplementalStore.status, .failed)
+        XCTAssertFalse(supplementalStore.shouldDisplayPayload(for: identity))
+    }
+
+    func testRefreshReplacesPayloadForSameTorrent() async throws {
+        let sender = MethodQueueSender(stepsByMethod: [
+            "session-stats": [
+                .http(statusCode: 200, body: successStatsBody)
+            ],
+            "torrent-get": [
+                .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json")),
+                .http(statusCode: 200, body: makeTorrentDetailSuccessBody(bytesCompleted: 1)),
+                .http(statusCode: 200, body: makeTorrentDetailSuccessBody(bytesCompleted: 2))
+            ],
+            "session-get": [
+                .http(statusCode: 200, body: try sessionSettingsBody(downloadDir: "/downloads/initial", version: "4.0.0"))
+            ]
+        ])
+        let transmissionStore = makeStore(sender: sender)
+        let supplementalStore = TorrentDetailSupplementalStore()
+        var errors: [String] = []
+
+        transmissionStore.setHost(host: makeHost(serverID: "server-1", server: "example.com"))
+        let didConnect = await waitUntil { transmissionStore.connectionStatus == .connected }
+        XCTAssertTrue(didConnect)
+        let identity = makeIdentity(torrentID: 42, store: transmissionStore)
+
+        await supplementalStore.refresh(for: identity, using: transmissionStore) { errors.append($0) }
+        XCTAssertEqual(supplementalStore.payload(for: identity).files.first?.bytesCompleted, 1)
+
+        await supplementalStore.refresh(for: identity, using: transmissionStore) { errors.append($0) }
+
+        XCTAssertEqual(errors, [])
+        XCTAssertEqual(supplementalStore.status, .loaded)
+        XCTAssertEqual(supplementalStore.payload(for: identity).files.first?.bytesCompleted, 2)
     }
 
     func testPayloadForActiveTorrentReflectsCommittedWantedMutationWithoutReload() {
@@ -115,12 +219,12 @@ final class TorrentDetailSupplementalStoreTests: XCTestCase {
         XCTAssertTrue(
             store.applyCommittedFileStatsMutation(
                 .wanted(false),
-                for: 42,
+                for: makeTestTorrentDetailIdentity(42),
                 fileIndices: [0]
             )
         )
 
-        let payload = store.payload(for: 42)
+        let payload = store.payload(for: makeTestTorrentDetailIdentity(42))
         XCTAssertFalse(payload.fileStats[0].wanted)
         XCTAssertEqual(payload.fileStats[0].priority, FilePriority.normal.rawValue)
         XCTAssertEqual(payload.fileStats[1], makeDetailSnapshot().fileStats[1])
@@ -132,12 +236,12 @@ final class TorrentDetailSupplementalStoreTests: XCTestCase {
         XCTAssertTrue(
             store.applyCommittedFileStatsMutation(
                 .priority(.high),
-                for: 42,
+                for: makeTestTorrentDetailIdentity(42),
                 fileIndices: [1]
             )
         )
 
-        let payload = store.payload(for: 42)
+        let payload = store.payload(for: makeTestTorrentDetailIdentity(42))
         XCTAssertEqual(payload.fileStats[1].priority, FilePriority.high.rawValue)
         XCTAssertFalse(payload.fileStats[1].wanted)
         XCTAssertEqual(payload.fileStats[0], makeDetailSnapshot().fileStats[0])
@@ -145,47 +249,82 @@ final class TorrentDetailSupplementalStoreTests: XCTestCase {
 
     func testApplyCommittedMutationForDifferentTorrentIsNoOp() {
         let store = makeLoadedStore()
-        let initialPayload = store.payload(for: 42)
+        let initialPayload = store.payload(for: makeTestTorrentDetailIdentity(42))
 
         XCTAssertFalse(
             store.applyCommittedFileStatsMutation(
                 .wanted(false),
-                for: 99,
+                for: makeTestTorrentDetailIdentity(99),
                 fileIndices: [0]
             )
         )
 
-        XCTAssertEqual(store.payload(for: 42), initialPayload)
+        XCTAssertEqual(store.payload(for: makeTestTorrentDetailIdentity(42)), initialPayload)
     }
 
     func testApplyCommittedMutationWithOutOfRangeIndicesIsNoOp() {
         let store = makeLoadedStore()
-        let initialPayload = store.payload(for: 42)
+        let initialPayload = store.payload(for: makeTestTorrentDetailIdentity(42))
 
         XCTAssertFalse(
             store.applyCommittedFileStatsMutation(
                 .priority(.low),
-                for: 42,
+                for: makeTestTorrentDetailIdentity(42),
                 fileIndices: [10]
             )
         )
 
-        XCTAssertEqual(store.payload(for: 42), initialPayload)
+        XCTAssertEqual(store.payload(for: makeTestTorrentDetailIdentity(42)), initialPayload)
     }
 }
 
-private extension TorrentDetailSupplementalStoreTests {
-    func makeTorrentDetailSuccessBody() -> String {
-        """
+@MainActor
+final class TorrentDetailIdentityStoreTests: XCTestCase {
+    func testLoadRejectsIdentityFromPreviousConnectionGeneration() async throws {
+        let sender = MethodQueueSender(stepsByMethod: [
+            "session-stats": [
+                .http(statusCode: 200, body: successStatsBody)
+            ],
+            "torrent-get": [
+                .http(statusCode: 200, body: try loadTransmissionFixture(named: "torrent-get.response.json"))
+            ],
+            "session-get": [
+                .http(
+                    statusCode: 200,
+                    body: try sessionSettingsBody(downloadDir: "/downloads/initial", version: "4.0.0")
+                )
+            ]
+        ])
+        let transmissionStore = makeStore(sender: sender)
+        let supplementalStore = TorrentDetailSupplementalStore()
+        var errors: [String] = []
+
+        transmissionStore.setHost(host: makeHost(serverID: "server-1", server: "example.com"))
+        let didConnect = await waitUntil { transmissionStore.connectionStatus == .connected }
+        XCTAssertTrue(didConnect)
+        let staleIdentity = makeTestTorrentDetailIdentity(42, connectionGeneration: UUID())
+
+        await supplementalStore.load(for: staleIdentity, using: transmissionStore) { errors.append($0) }
+
+        let methods = try await sender.capturedRequests().map { try requestMethod(from: $0.asURLRequest()) }
+        XCTAssertEqual(methods.filter { $0 == "torrent-get" }.count, 1)
+        XCTAssertEqual(errors, [])
+        XCTAssertEqual(supplementalStore.status, .idle)
+        XCTAssertEqual(supplementalStore.payload(for: staleIdentity), .empty)
+    }
+}
+
+func makeTorrentDetailSuccessBody(bytesCompleted: Int = 1) -> String {
+    """
         {
           "arguments": {
-            "torrents": [
-              {
-                "files": [
-                  { "bytesCompleted": 1, "length": 2, "name": "Ubuntu.iso" }
-                ],
-                "fileStats": [
-                  { "bytesCompleted": 1, "wanted": true, "priority": 0 }
+                "torrents": [
+                  {
+                    "files": [
+                      { "bytesCompleted": \(bytesCompleted), "length": 2, "name": "Ubuntu.iso" }
+                    ],
+                    "fileStats": [
+                      { "bytesCompleted": \(bytesCompleted), "wanted": true, "priority": 0 }
                 ],
                 "peers": [
                   {
@@ -224,7 +363,15 @@ private extension TorrentDetailSupplementalStoreTests {
           },
           "result": "success"
         }
-        """
+    """
+}
+
+private extension TorrentDetailSupplementalStoreTests {
+    func makeIdentity(torrentID: Int, store: TransmissionStore) -> TorrentDetailIdentity {
+        TorrentDetailIdentity(
+            torrentID: torrentID,
+            connectionGeneration: store.torrentDetailRefreshTrigger.connectionGeneration
+        )
     }
 
     func rpcFailureBody(result: String) -> String {
@@ -238,11 +385,12 @@ private extension TorrentDetailSupplementalStoreTests {
 
     func makeLoadedStore(torrentID: Int = 42) -> TorrentDetailSupplementalStore {
         var state = TorrentDetailSupplementalState()
-        let generation = state.beginLoading(for: torrentID)
+        let identity = makeTestTorrentDetailIdentity(torrentID)
+        let generation = state.beginLoading(for: identity)
         XCTAssertTrue(
             state.apply(
                 snapshot: makeDetailSnapshot(),
-                for: torrentID,
+                for: identity,
                 generation: generation
             )
         )


### PR DESCRIPTION
## Summary

- refresh supplemental torrent files, peers, and pieces while the detail view remains open
- consolidate supplemental fields into one Transmission RPC query
- scope cached detail state to the torrent and active connection generation
- serialize and deduplicate loads, coalesce polling revisions, and reject stale responses
- limit heavyweight background detail refreshes to a 30-second cadence while keeping initial and manual refreshes immediate

## Root cause

Supplemental detail data was loaded independently from the regularly refreshed torrent summary and remained cached until the selected torrent changed. Connecting detail refreshes directly to every normal poll would fix staleness but create excessive bandwidth, decoding, allocation, and UI-update work for large torrents.

This change adds a connection-aware supplemental store and a dedicated refresh policy so details update automatically without request races or heavyweight downloads at the list polling rate.
