### PR TITLE
Add optional Dock transfer rate badges

### DIFF
--- a/BitDream/AppConfig.swift
+++ b/BitDream/AppConfig.swift
@@ -38,6 +38,8 @@ enum AppDefaults {
     static let menuBarShowActiveCount: Bool = true
     static let menuBarSortMode: MenuBarSortMode = .activity
     static let dockShowCompletedBadge: Bool = true
+    static let dockShowDownloadSpeed: Bool = false
+    static let dockShowUploadSpeed: Bool = false
     static let pollInterval: Double = 5.0
     static let torrentDetailRefreshInterval: TimeInterval = 30.0
     static let ratioDisplayMode: RatioDisplayMode = .cumulative
@@ -67,6 +69,8 @@ enum UserDefaultsKeys {
     static let menuBarShowActiveCount = "menuBarShowActiveCount"
     static let menuBarSortMode = "menuBarSortMode"
     static let dockShowCompletedBadge = "dockShowCompletedBadge"
+    static let dockShowDownloadSpeed = "dockShowDownloadSpeed"
+    static let dockShowUploadSpeed = "dockShowUploadSpeed"
     static let ratioDisplayMode = "ratioDisplayMode"
     static let selectedHost = "selectedHost"
     static let startupConnectionBehavior = "startupConnectionBehavior"

--- a/BitDream/Views/Shared/Settings/SettingsView.swift
+++ b/BitDream/Views/Shared/Settings/SettingsView.swift
@@ -32,6 +32,8 @@ struct SettingsView: View {
         UserDefaults.standard.set(AppDefaults.menuBarShowActiveCount, forKey: UserDefaultsKeys.menuBarShowActiveCount)
         UserDefaults.standard.set(AppDefaults.menuBarSortMode.rawValue, forKey: UserDefaultsKeys.menuBarSortMode)
         UserDefaults.standard.set(AppDefaults.dockShowCompletedBadge, forKey: UserDefaultsKeys.dockShowCompletedBadge)
+        UserDefaults.standard.set(AppDefaults.dockShowDownloadSpeed, forKey: UserDefaultsKeys.dockShowDownloadSpeed)
+        UserDefaults.standard.set(AppDefaults.dockShowUploadSpeed, forKey: UserDefaultsKeys.dockShowUploadSpeed)
         UserDefaults.standard.set(AppDefaults.startupConnectionBehavior.rawValue, forKey: UserDefaultsKeys.startupConnectionBehavior)
 
         // Poll interval via TransmissionStore API

--- a/BitDream/Views/macOS/DockBadgeController.swift
+++ b/BitDream/Views/macOS/DockBadgeController.swift
@@ -1,59 +1,153 @@
 #if os(macOS)
 import AppKit
 import Combine
+import Foundation
 import SwiftUI
 
-// Keeps the Dock icon badge in sync with the completed torrent count,
-// independent of the main window's lifecycle. The badge reflects live app
-// state, so NSDockTile is used rather than UNUserNotificationCenter's
-// badge APIs (which target persistent, notification-driven unread counts).
+private struct DockBadgeMetrics: Equatable {
+    var isConnected = false
+    var completedTorrentCount = 0
+    var downloadSpeed: Int64 = 0
+    var uploadSpeed: Int64 = 0
+}
+
+private struct DockBadgePreferences: Equatable {
+    let showCompleted: Bool
+    let showDownload: Bool
+    let showUpload: Bool
+
+    init(defaults: UserDefaults) {
+        showCompleted = defaults.object(forKey: UserDefaultsKeys.dockShowCompletedBadge) as? Bool
+            ?? AppDefaults.dockShowCompletedBadge
+        showDownload = defaults.object(forKey: UserDefaultsKeys.dockShowDownloadSpeed) as? Bool
+            ?? AppDefaults.dockShowDownloadSpeed
+        showUpload = defaults.object(forKey: UserDefaultsKeys.dockShowUploadSpeed) as? Bool
+            ?? AppDefaults.dockShowUploadSpeed
+    }
+}
+
 @MainActor
 final class DockBadgeController: ObservableObject {
+    private let defaults: UserDefaults
     private weak var store: TransmissionStore?
     private var cancellables = Set<AnyCancellable>()
+    private var metrics = DockBadgeMetrics()
+    private var preferences: DockBadgePreferences
+    private var speedTileView: DockSpeedTileHostingView?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        preferences = DockBadgePreferences(defaults: defaults)
+    }
 
     func configure(store: TransmissionStore) {
+        preferences = DockBadgePreferences(defaults: defaults)
         if self.store !== store || cancellables.isEmpty {
+            metrics = DockBadgeMetrics()
             self.store = store
             observeChanges(store)
         }
-        refresh()
+        updateDockTile()
     }
 
     private func observeChanges(_ store: TransmissionStore) {
         cancellables.removeAll()
 
-        store.objectWillChange
+        let transferRates = store.$sessionStats
+            .map { stats in
+                (
+                    download: stats?.downloadSpeed ?? 0,
+                    upload: stats?.uploadSpeed ?? 0
+                )
+            }
+
+        let completedTorrentCount = store.$torrents
+            .map { torrents in
+                torrents.lazy.filter { $0.statusCalc == .complete }.count
+            }
+
+        let isConnected = store.$connectionStatus
+            .map { status in
+                if case .connected = status { return true }
+                return false
+            }
+
+        Publishers.CombineLatest3(transferRates, completedTorrentCount, isConnected)
+            .map { transferRates, completedTorrentCount, isConnected in
+                DockBadgeMetrics(
+                    isConnected: isConnected,
+                    completedTorrentCount: completedTorrentCount,
+                    downloadSpeed: transferRates.download,
+                    uploadSpeed: transferRates.upload
+                )
+            }
+            .removeDuplicates()
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
-                self?.refresh()
+            .sink { [weak self] metrics in
+                self?.metrics = metrics
+                self?.updateDockTile()
             }
             .store(in: &cancellables)
 
-        // Reflect settings changes immediately, even when no window is open.
-        NotificationCenter.default
-            .publisher(for: UserDefaults.didChangeNotification)
+        NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification, object: defaults)
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
-                self?.refresh()
+            .map { [defaults] _ in DockBadgePreferences(defaults: defaults) }
+            .removeDuplicates()
+            .sink { [weak self] preferences in
+                guard let self, preferences != self.preferences else { return }
+                self.preferences = preferences
+                self.updateDockTile()
             }
             .store(in: &cancellables)
     }
 
-    private func refresh() {
-        let isEnabled = (UserDefaults.standard.object(forKey: UserDefaultsKeys.dockShowCompletedBadge) as? Bool)
-            ?? AppDefaults.dockShowCompletedBadge
-        let count = isEnabled ? completedTorrentsCount() : 0
-        let badgeLabel = count > 0 ? "\(count)" : nil
+    private func updateDockTile() {
+        let dockTile = NSApplication.shared.dockTile
+        let badgeLabel = metrics.isConnected && preferences.showCompleted && metrics.completedTorrentCount > 0
+            ? String(metrics.completedTorrentCount)
+            : nil
+        var needsDisplay = false
 
-        if NSApplication.shared.dockTile.badgeLabel != badgeLabel {
-            NSApplication.shared.dockTile.badgeLabel = badgeLabel
+        if dockTile.badgeLabel != badgeLabel {
+            dockTile.badgeLabel = badgeLabel
+            needsDisplay = true
+        }
+
+        let content = DockSpeedTileContent(
+            downloadSpeed: speedValue(isEnabled: preferences.showDownload, bytesPerSecond: metrics.downloadSpeed),
+            uploadSpeed: speedValue(isEnabled: preferences.showUpload, bytesPerSecond: metrics.uploadSpeed)
+        )
+
+        if content.downloadSpeed != nil || content.uploadSpeed != nil {
+            let alreadyInstalled = dockTile.contentView === speedTileView
+            let speedTileView = installedSpeedTileView(for: dockTile)
+            needsDisplay = !alreadyInstalled || speedTileView.update(content: content) || needsDisplay
+        } else if dockTile.contentView === speedTileView {
+            dockTile.contentView = nil
+            speedTileView = nil
+            needsDisplay = true
+        }
+
+        if needsDisplay {
+            dockTile.display()
         }
     }
 
-    private func completedTorrentsCount() -> Int {
-        guard let store, store.connectionStatus == .connected else { return 0 }
-        return store.torrents.filter { $0.statusCalc == .complete }.count
+    private func speedValue(isEnabled: Bool, bytesPerSecond: Int64) -> Int64? {
+        guard metrics.isConnected, isEnabled, bytesPerSecond > 0 else { return nil }
+        return bytesPerSecond
+    }
+
+    private func installedSpeedTileView(for dockTile: NSDockTile) -> DockSpeedTileHostingView {
+        if let speedTileView, dockTile.contentView === speedTileView {
+            return speedTileView
+        }
+
+        let view = DockSpeedTileHostingView(frame: NSRect(origin: .zero, size: dockTile.size))
+        view.autoresizingMask = [.width, .height]
+        dockTile.contentView = view
+        speedTileView = view
+        return view
     }
 }
 #endif

--- a/BitDream/Views/macOS/DockSpeedTileView.swift
+++ b/BitDream/Views/macOS/DockSpeedTileView.swift
@@ -1,0 +1,114 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+struct DockSpeedTileContent: Equatable {
+    let downloadSpeed: Int64?
+    let uploadSpeed: Int64?
+}
+
+@MainActor
+final class DockSpeedTileHostingView: NSHostingView<DockSpeedTileView> {
+    private var content = DockSpeedTileContent(downloadSpeed: nil, uploadSpeed: nil)
+
+    init(frame: NSRect) {
+        let initialContent = DockSpeedTileContent(downloadSpeed: nil, uploadSpeed: nil)
+        super.init(rootView: DockSpeedTileView(content: initialContent))
+        self.frame = frame
+    }
+
+    @available(*, unavailable)
+    required init(rootView: DockSpeedTileView) {
+        fatalError("Use init(frame:)")
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("Use init(frame:)")
+    }
+
+    func update(content: DockSpeedTileContent) -> Bool {
+        guard self.content != content else { return false }
+        self.content = content
+        rootView = DockSpeedTileView(content: content)
+        return true
+    }
+}
+
+struct DockSpeedTileView: View {
+    let content: DockSpeedTileContent
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                Image(nsImage: NSApplication.shared.applicationIconImage)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+
+                VStack(spacing: 2) {
+                    Spacer(minLength: 0)
+                    if let uploadSpeed = content.uploadSpeed {
+                        DockSpeedBadge(speed: uploadSpeed, direction: .upload, width: geometry.size.width)
+                    }
+                    if let downloadSpeed = content.downloadSpeed {
+                        DockSpeedBadge(speed: downloadSpeed, direction: .download, width: geometry.size.width)
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        let rates = [
+            content.downloadSpeed.map { "Download speed, \(formatSpeed($0))" },
+            content.uploadSpeed.map { "Upload speed, \(formatSpeed($0))" }
+        ].compactMap { $0 }
+        return (["BitDream"] + rates).joined(separator: ". ")
+    }
+}
+
+private struct DockSpeedBadge: View {
+    let speed: Int64
+    let direction: SpeedDirection
+    let width: CGFloat
+
+    var body: some View {
+        let formattedSpeed = DockTransferRateFormatter.components(for: speed)
+
+        ZStack {
+            Capsule()
+                .fill(backgroundColor)
+
+            HStack(spacing: 5) {
+                Image(systemName: direction.icon)
+                    .font(.system(size: 16, weight: .heavy))
+                    .frame(width: 18)
+
+                HStack(spacing: 2) {
+                    Text(formattedSpeed.value)
+                    Text(formattedSpeed.unit)
+                }
+                .font(.system(size: 25, weight: .bold, design: .monospaced))
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 10)
+        }
+        .frame(width: width, height: 30)
+        .accessibilityLabel("\(direction.helpText), \(formatSpeed(speed))")
+    }
+
+    private var backgroundColor: Color {
+        switch direction {
+        case .download:
+            return Color(red: 0 / 255, green: 116 / 255, blue: 232 / 255)
+        case .upload:
+            return Color(red: 32 / 255, green: 140 / 255, blue: 64 / 255)
+        }
+    }
+}
+#endif

--- a/BitDream/Views/macOS/DockTransferRateFormatter.swift
+++ b/BitDream/Views/macOS/DockTransferRateFormatter.swift
@@ -1,0 +1,55 @@
+#if os(macOS)
+import Foundation
+
+struct DockTransferRateComponents: Equatable {
+    let value: String
+    let unit: String
+}
+
+enum DockTransferRateFormatter {
+    private struct UnitScale {
+        let divisor: Double
+        let suffix: String
+    }
+
+    private static let units = [
+        UnitScale(divisor: 1, suffix: "B"),
+        UnitScale(divisor: 1_000, suffix: "k"),
+        UnitScale(divisor: 1_000_000, suffix: "M"),
+        UnitScale(divisor: 1_000_000_000, suffix: "G"),
+        UnitScale(divisor: 1_000_000_000_000, suffix: "T"),
+        UnitScale(divisor: 1_000_000_000_000_000, suffix: "P"),
+        UnitScale(divisor: 1_000_000_000_000_000_000, suffix: "E")
+    ]
+
+    static func components(
+        for bytesPerSecond: Int64,
+        locale: Locale = .autoupdatingCurrent
+    ) -> DockTransferRateComponents {
+        let bytesPerSecond = max(0, bytesPerSecond)
+        guard bytesPerSecond > 0 else { return DockTransferRateComponents(value: "0", unit: "B") }
+
+        var unitIndex = units.lastIndex { Double(bytesPerSecond) >= $0.divisor } ?? 0
+        var scaledValue = roundedScaledValue(bytesPerSecond, unitIndex: unitIndex)
+
+        if scaledValue >= 1_000, unitIndex < units.index(before: units.endIndex) {
+            unitIndex += 1
+            scaledValue = roundedScaledValue(bytesPerSecond, unitIndex: unitIndex)
+        }
+
+        let fractionDigits = scaledValue < 100 ? 1 : 0
+        let value = scaledValue.formatted(
+            .number
+                .locale(locale)
+                .precision(.fractionLength(0...fractionDigits))
+        )
+        return DockTransferRateComponents(value: value, unit: units[unitIndex].suffix)
+    }
+
+    private static func roundedScaledValue(_ bytesPerSecond: Int64, unitIndex: Int) -> Double {
+        let scaledValue = Double(bytesPerSecond) / units[unitIndex].divisor
+        let roundingScale = scaledValue < 100 ? 10.0 : 1.0
+        return (scaledValue * roundingScale).rounded() / roundingScale
+    }
+}
+#endif

--- a/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
+++ b/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
@@ -12,7 +12,9 @@ struct macOSGeneralSettingsTab: View {
     @AppStorage(UserDefaultsKeys.menuBarShowActiveCount) private var menuBarShowActiveCount: Bool = AppDefaults.menuBarShowActiveCount
     @AppStorage(UserDefaultsKeys.menuBarSortMode) private var menuBarSortModeRaw: String = AppDefaults.menuBarSortMode.rawValue
     @AppStorage(UserDefaultsKeys.startupConnectionBehavior) private var startupBehaviorRaw: String = AppDefaults.startupConnectionBehavior.rawValue
-    @AppStorage(UserDefaultsKeys.dockShowCompletedBadge) private var dockShowCompletedBadge: Bool = AppDefaults.dockShowCompletedBadge
+    @AppStorage(UserDefaultsKeys.dockShowCompletedBadge) private var dockShowCompletedBadge = AppDefaults.dockShowCompletedBadge
+    @AppStorage(UserDefaultsKeys.dockShowDownloadSpeed) private var dockShowDownloadSpeed = AppDefaults.dockShowDownloadSpeed
+    @AppStorage(UserDefaultsKeys.dockShowUploadSpeed) private var dockShowUploadSpeed = AppDefaults.dockShowUploadSpeed
 
     private var menuBarSortMode: Binding<MenuBarSortMode> {
         Binding<MenuBarSortMode>(
@@ -115,6 +117,14 @@ struct macOSGeneralSettingsTab: View {
 
                     divider
 
+                    settingsSection("Dock Badge") {
+                        Toggle("Completed torrents", isOn: $dockShowCompletedBadge)
+                        Toggle("Total download rate", isOn: $dockShowDownloadSpeed)
+                        Toggle("Total upload rate", isOn: $dockShowUploadSpeed)
+                    }
+
+                    divider
+
                     settingsSection("Connection Settings") {
                         HStack {
                             Text("Startup connection")
@@ -161,9 +171,6 @@ struct macOSGeneralSettingsTab: View {
                     divider
 
                     settingsSection("Notifications") {
-                        Toggle("Show Dock badge for completed torrents", isOn: $dockShowCompletedBadge)
-                            .help("Show the number of completed torrents on BitDream's Dock icon.")
-
                         Toggle("Show notifications for completed torrents", isOn: .constant(false))
                             .disabled(true)
 

--- a/BitDreamTests/Views/DockTransferRateFormatterTests.swift
+++ b/BitDreamTests/Views/DockTransferRateFormatterTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+@testable import BitDream
+
+#if os(macOS)
+final class DockTransferRateFormatterTests: XCTestCase {
+    private let locale = Locale(identifier: "en_US_POSIX")
+
+    func testComponentsUseCompactDecimalUnits() {
+        XCTAssertEqual(components(1), DockTransferRateComponents(value: "1", unit: "B"))
+        XCTAssertEqual(components(999), DockTransferRateComponents(value: "999", unit: "B"))
+        XCTAssertEqual(components(1_000), DockTransferRateComponents(value: "1", unit: "k"))
+        XCTAssertEqual(components(19_200_000), DockTransferRateComponents(value: "19.2", unit: "M"))
+        XCTAssertEqual(components(4_100_000_000), DockTransferRateComponents(value: "4.1", unit: "G"))
+        XCTAssertEqual(components(Int64.max), DockTransferRateComponents(value: "9.2", unit: "E"))
+    }
+
+    func testComponentsPromoteValuesThatRoundIntoTheNextUnit() {
+        XCTAssertEqual(components(999_500), DockTransferRateComponents(value: "1", unit: "M"))
+        XCTAssertEqual(components(999_499), DockTransferRateComponents(value: "999", unit: "k"))
+    }
+
+    func testComponentsHonorLocale() {
+        let result = DockTransferRateFormatter.components(
+            for: 19_200_000,
+            locale: Locale(identifier: "fr_FR")
+        )
+
+        XCTAssertEqual(result, DockTransferRateComponents(value: "19,2", unit: "M"))
+    }
+
+    func testComponentsClampNonpositiveRatesToZero() {
+        XCTAssertEqual(components(0), DockTransferRateComponents(value: "0", unit: "B"))
+        XCTAssertEqual(components(-1), DockTransferRateComponents(value: "0", unit: "B"))
+    }
+
+    private func components(_ bytesPerSecond: Int64) -> DockTransferRateComponents {
+        DockTransferRateFormatter.components(for: bytesPerSecond, locale: locale)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- add independent Dock Badge settings for completed torrents, total download rate, and total upload rate
- render active transfer rates with a SwiftUI Dock tile hosted through Apple’s `NSDockTile.contentView` API
- keep completed torrents on the native Dock badge while restoring the standard app icon whenever no speed badge is active
- add compact, locale-aware transfer-rate formatting with focused unit coverage

## Behavior

Download and upload badges update from live Transmission session statistics. Enabled directions appear only while their rate is nonzero; upload is positioned above download when both are active. Preference changes take effect immediately without tying updates to the settings window lifecycle.

