### PR TITLE
Add optional Dock transfer rate badges

### DIFF
--- a/BitDream/AppConfig.swift
+++ b/BitDream/AppConfig.swift
@@ -38,6 +38,8 @@ enum AppDefaults {
     static let menuBarShowActiveCount: Bool = true
     static let menuBarSortMode: MenuBarSortMode = .activity
     static let dockShowCompletedBadge: Bool = true
+    static let dockShowDownloadSpeed: Bool = false
+    static let dockShowUploadSpeed: Bool = false
     static let pollInterval: Double = 5.0
     static let torrentDetailRefreshInterval: TimeInterval = 30.0
     static let ratioDisplayMode: RatioDisplayMode = .cumulative
@@ -67,6 +69,8 @@ enum UserDefaultsKeys {
     static let menuBarShowActiveCount = "menuBarShowActiveCount"
     static let menuBarSortMode = "menuBarSortMode"
     static let dockShowCompletedBadge = "dockShowCompletedBadge"
+    static let dockShowDownloadSpeed = "dockShowDownloadSpeed"
+    static let dockShowUploadSpeed = "dockShowUploadSpeed"
     static let ratioDisplayMode = "ratioDisplayMode"
     static let selectedHost = "selectedHost"
     static let startupConnectionBehavior = "startupConnectionBehavior"

--- a/BitDream/Formatting.swift
+++ b/BitDream/Formatting.swift
@@ -1,26 +1,74 @@
 import Foundation
 
+struct CompactByteCountComponents {
+    let value: String
+    let unit: String
+}
+
+private let byteCountFormatStyle = ByteCountFormatStyle(
+    style: .file,
+    allowedUnits: [.kb, .mb, .gb, .tb],
+    spellsOutZero: false,
+    includesActualByteCount: false
+)
+
 /// Shared byte formatting helper using modern format style.
 /// Round up 1 to 999 bytes to 1 kB.
 public func formatByteCount(_ bytes: Int64) -> String {
-    if bytes == 0 {
-        return "0 kB"
-    }
-    if bytes > 0 && bytes < 1_000 {
-        return "1 kB"
-    }
-    return bytes.formatted(
-        ByteCountFormatStyle(
-            style: .file,
-            allowedUnits: [.kb, .mb, .gb, .tb],
-            spellsOutZero: false,
-            includesActualByteCount: false
-        )
-    )
+    String(formattedByteCount(bytes).characters)
 }
 
 /// Shared speed formatting helper (bytes per second -> short string).
 func formatSpeed(_ bytesPerSecond: Int64) -> String {
     let base = formatByteCount(bytesPerSecond)
     return "\(base)/s"
+}
+
+func formatCompactByteCount(_ bytes: Int64) -> CompactByteCountComponents {
+    let formatted = formattedByteCount(bytes)
+    var value = ""
+    var unit = ""
+
+    for run in formatted.runs {
+        let text = String(formatted[run.range].characters)
+        switch run.byteCount {
+        case .value:
+            value += text
+        case let .unit(byteCountUnit):
+            unit = compactSuffix(for: byteCountUnit)
+        default:
+            break
+        }
+    }
+
+    return CompactByteCountComponents(value: value, unit: unit)
+}
+
+private func formattedByteCount(_ bytes: Int64) -> AttributedString {
+    let normalizedBytes: Int64
+    if bytes == 0 {
+        normalizedBytes = 0
+    } else if bytes > 0 && bytes < 1_000 {
+        normalizedBytes = 1_000
+    } else {
+        normalizedBytes = bytes
+    }
+    return byteCountFormatStyle.attributed.format(normalizedBytes)
+}
+
+private func compactSuffix(
+    for unit: AttributeScopes.FoundationAttributes.ByteCountAttribute.Unit
+) -> String {
+    switch unit {
+    case .byte: "B"
+    case .kb: "k"
+    case .mb: "M"
+    case .gb: "G"
+    case .tb: "T"
+    case .pb: "P"
+    case .eb: "E"
+    case .zb: "Z"
+    case .yb: "Y"
+    @unknown default: ""
+    }
 }

--- a/BitDream/Views/Shared/Settings/SettingsView.swift
+++ b/BitDream/Views/Shared/Settings/SettingsView.swift
@@ -32,6 +32,8 @@ struct SettingsView: View {
         UserDefaults.standard.set(AppDefaults.menuBarShowActiveCount, forKey: UserDefaultsKeys.menuBarShowActiveCount)
         UserDefaults.standard.set(AppDefaults.menuBarSortMode.rawValue, forKey: UserDefaultsKeys.menuBarSortMode)
         UserDefaults.standard.set(AppDefaults.dockShowCompletedBadge, forKey: UserDefaultsKeys.dockShowCompletedBadge)
+        UserDefaults.standard.set(AppDefaults.dockShowDownloadSpeed, forKey: UserDefaultsKeys.dockShowDownloadSpeed)
+        UserDefaults.standard.set(AppDefaults.dockShowUploadSpeed, forKey: UserDefaultsKeys.dockShowUploadSpeed)
         UserDefaults.standard.set(AppDefaults.startupConnectionBehavior.rawValue, forKey: UserDefaultsKeys.startupConnectionBehavior)
 
         // Poll interval via TransmissionStore API

--- a/BitDream/Views/macOS/DockBadgeController.swift
+++ b/BitDream/Views/macOS/DockBadgeController.swift
@@ -1,59 +1,158 @@
 #if os(macOS)
 import AppKit
 import Combine
+import Foundation
 import SwiftUI
 
-// Keeps the Dock icon badge in sync with the completed torrent count,
-// independent of the main window's lifecycle. The badge reflects live app
-// state, so NSDockTile is used rather than UNUserNotificationCenter's
-// badge APIs (which target persistent, notification-driven unread counts).
+private struct DockBadgeMetrics: Equatable {
+    var isConnected = false
+    var completedTorrentCount = 0
+    var downloadSpeed: Int64 = 0
+    var uploadSpeed: Int64 = 0
+}
+
+private struct DockBadgePreferences: Equatable {
+    let showCompleted: Bool
+    let showDownload: Bool
+    let showUpload: Bool
+
+    init(defaults: UserDefaults) {
+        showCompleted = defaults.object(forKey: UserDefaultsKeys.dockShowCompletedBadge) as? Bool
+            ?? AppDefaults.dockShowCompletedBadge
+        showDownload = defaults.object(forKey: UserDefaultsKeys.dockShowDownloadSpeed) as? Bool
+            ?? AppDefaults.dockShowDownloadSpeed
+        showUpload = defaults.object(forKey: UserDefaultsKeys.dockShowUploadSpeed) as? Bool
+            ?? AppDefaults.dockShowUploadSpeed
+    }
+}
+
+// Keeps the completed-torrent badge and live transfer-rate tile in sync with
+// Transmission state, independent of the main window's lifecycle. NSDockTile
+// is used instead of notification badge APIs because these values represent
+// live application state rather than persistent notification state.
 @MainActor
 final class DockBadgeController: ObservableObject {
+    private let defaults: UserDefaults
     private weak var store: TransmissionStore?
     private var cancellables = Set<AnyCancellable>()
+    private var metrics = DockBadgeMetrics()
+    private var preferences: DockBadgePreferences
+    private var speedTileView: DockSpeedTileHostingView?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        preferences = DockBadgePreferences(defaults: defaults)
+    }
 
     func configure(store: TransmissionStore) {
+        preferences = DockBadgePreferences(defaults: defaults)
         if self.store !== store || cancellables.isEmpty {
+            metrics = DockBadgeMetrics()
             self.store = store
             observeChanges(store)
         }
-        refresh()
+        updateDockTile()
     }
 
     private func observeChanges(_ store: TransmissionStore) {
         cancellables.removeAll()
 
-        store.objectWillChange
+        let transferRates = store.$sessionStats
+            .map { stats in
+                (
+                    download: stats?.downloadSpeed ?? 0,
+                    upload: stats?.uploadSpeed ?? 0
+                )
+            }
+
+        let completedTorrentCount = store.$torrents
+            .map { torrents in
+                torrents.lazy.filter { $0.statusCalc == .complete }.count
+            }
+
+        let isConnected = store.$connectionStatus
+            .map { status in
+                if case .connected = status { return true }
+                return false
+            }
+
+        Publishers.CombineLatest3(transferRates, completedTorrentCount, isConnected)
+            .map { transferRates, completedTorrentCount, isConnected in
+                DockBadgeMetrics(
+                    isConnected: isConnected,
+                    completedTorrentCount: completedTorrentCount,
+                    downloadSpeed: transferRates.download,
+                    uploadSpeed: transferRates.upload
+                )
+            }
+            .removeDuplicates()
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
-                self?.refresh()
+            .sink { [weak self] metrics in
+                self?.metrics = metrics
+                self?.updateDockTile()
             }
             .store(in: &cancellables)
 
-        // Reflect settings changes immediately, even when no window is open.
-        NotificationCenter.default
-            .publisher(for: UserDefaults.didChangeNotification)
+        // Reflect Dock badge settings immediately, even when no settings window is open.
+        NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification, object: defaults)
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
-                self?.refresh()
+            .map { [defaults] _ in DockBadgePreferences(defaults: defaults) }
+            .removeDuplicates()
+            .sink { [weak self] preferences in
+                guard let self, preferences != self.preferences else { return }
+                self.preferences = preferences
+                self.updateDockTile()
             }
             .store(in: &cancellables)
     }
 
-    private func refresh() {
-        let isEnabled = (UserDefaults.standard.object(forKey: UserDefaultsKeys.dockShowCompletedBadge) as? Bool)
-            ?? AppDefaults.dockShowCompletedBadge
-        let count = isEnabled ? completedTorrentsCount() : 0
-        let badgeLabel = count > 0 ? "\(count)" : nil
+    private func updateDockTile() {
+        let dockTile = NSApplication.shared.dockTile
+        let badgeLabel = metrics.isConnected && preferences.showCompleted && metrics.completedTorrentCount > 0
+            ? String(metrics.completedTorrentCount)
+            : nil
+        var needsDisplay = false
 
-        if NSApplication.shared.dockTile.badgeLabel != badgeLabel {
-            NSApplication.shared.dockTile.badgeLabel = badgeLabel
+        if dockTile.badgeLabel != badgeLabel {
+            dockTile.badgeLabel = badgeLabel
+            needsDisplay = true
+        }
+
+        let content = DockSpeedTileContent(
+            downloadSpeed: speedValue(isEnabled: preferences.showDownload, bytesPerSecond: metrics.downloadSpeed),
+            uploadSpeed: speedValue(isEnabled: preferences.showUpload, bytesPerSecond: metrics.uploadSpeed)
+        )
+
+        if content.downloadSpeed != nil || content.uploadSpeed != nil {
+            let alreadyInstalled = dockTile.contentView === speedTileView
+            let speedTileView = installedSpeedTileView(for: dockTile)
+            needsDisplay = !alreadyInstalled || speedTileView.update(content: content) || needsDisplay
+        } else if dockTile.contentView === speedTileView {
+            dockTile.contentView = nil
+            speedTileView = nil
+            needsDisplay = true
+        }
+
+        if needsDisplay {
+            dockTile.display()
         }
     }
 
-    private func completedTorrentsCount() -> Int {
-        guard let store, store.connectionStatus == .connected else { return 0 }
-        return store.torrents.filter { $0.statusCalc == .complete }.count
+    private func speedValue(isEnabled: Bool, bytesPerSecond: Int64) -> Int64? {
+        guard metrics.isConnected, isEnabled, bytesPerSecond > 0 else { return nil }
+        return bytesPerSecond
+    }
+
+    private func installedSpeedTileView(for dockTile: NSDockTile) -> DockSpeedTileHostingView {
+        if let speedTileView, dockTile.contentView === speedTileView {
+            return speedTileView
+        }
+
+        let view = DockSpeedTileHostingView(frame: NSRect(origin: .zero, size: dockTile.size))
+        view.autoresizingMask = [.width, .height]
+        dockTile.contentView = view
+        speedTileView = view
+        return view
     }
 }
 #endif

--- a/BitDream/Views/macOS/DockSpeedTileView.swift
+++ b/BitDream/Views/macOS/DockSpeedTileView.swift
@@ -49,12 +49,13 @@ struct DockSpeedTileView: View {
                 VStack(spacing: 2) {
                     Spacer(minLength: 0)
                     if let uploadSpeed = content.uploadSpeed {
-                        DockSpeedBadge(speed: uploadSpeed, direction: .upload, width: geometry.size.width)
+                        DockSpeedBadge(speed: uploadSpeed, direction: .upload)
                     }
                     if let downloadSpeed = content.downloadSpeed {
-                        DockSpeedBadge(speed: downloadSpeed, direction: .download, width: geometry.size.width)
+                        DockSpeedBadge(speed: downloadSpeed, direction: .download)
                     }
                 }
+                .padding(.horizontal, 4)
             }
         }
         .accessibilityElement(children: .combine)
@@ -73,7 +74,6 @@ struct DockSpeedTileView: View {
 private struct DockSpeedBadge: View {
     let speed: Int64
     let direction: SpeedDirection
-    let width: CGFloat
 
     var body: some View {
         let formattedSpeed = formatCompactByteCount(speed)
@@ -91,6 +91,7 @@ private struct DockSpeedBadge: View {
                     Text(formattedSpeed.value)
                     Text(formattedSpeed.unit)
                 }
+                .frame(width: 72)
                 .font(.system(size: 25, weight: .bold, design: .monospaced))
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
@@ -98,7 +99,7 @@ private struct DockSpeedBadge: View {
             .foregroundStyle(.white)
             .padding(.horizontal, 10)
         }
-        .frame(width: width, height: 30)
+        .frame(maxWidth: .infinity, minHeight: 30, maxHeight: 30)
         .accessibilityLabel("\(direction.helpText), \(formatSpeed(speed))")
     }
 

--- a/BitDream/Views/macOS/DockSpeedTileView.swift
+++ b/BitDream/Views/macOS/DockSpeedTileView.swift
@@ -1,0 +1,114 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+struct DockSpeedTileContent: Equatable {
+    let downloadSpeed: Int64?
+    let uploadSpeed: Int64?
+}
+
+@MainActor
+final class DockSpeedTileHostingView: NSHostingView<DockSpeedTileView> {
+    private var content = DockSpeedTileContent(downloadSpeed: nil, uploadSpeed: nil)
+
+    init(frame: NSRect) {
+        let initialContent = DockSpeedTileContent(downloadSpeed: nil, uploadSpeed: nil)
+        super.init(rootView: DockSpeedTileView(content: initialContent))
+        self.frame = frame
+    }
+
+    @available(*, unavailable)
+    required init(rootView: DockSpeedTileView) {
+        fatalError("Use init(frame:)")
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("Use init(frame:)")
+    }
+
+    func update(content: DockSpeedTileContent) -> Bool {
+        guard self.content != content else { return false }
+        self.content = content
+        rootView = DockSpeedTileView(content: content)
+        return true
+    }
+}
+
+struct DockSpeedTileView: View {
+    let content: DockSpeedTileContent
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                Image(nsImage: NSApplication.shared.applicationIconImage)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+
+                VStack(spacing: 2) {
+                    Spacer(minLength: 0)
+                    if let uploadSpeed = content.uploadSpeed {
+                        DockSpeedBadge(speed: uploadSpeed, direction: .upload, width: geometry.size.width)
+                    }
+                    if let downloadSpeed = content.downloadSpeed {
+                        DockSpeedBadge(speed: downloadSpeed, direction: .download, width: geometry.size.width)
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        let rates = [
+            content.downloadSpeed.map { "Download speed, \(formatSpeed($0))" },
+            content.uploadSpeed.map { "Upload speed, \(formatSpeed($0))" }
+        ].compactMap { $0 }
+        return (["BitDream"] + rates).joined(separator: ". ")
+    }
+}
+
+private struct DockSpeedBadge: View {
+    let speed: Int64
+    let direction: SpeedDirection
+    let width: CGFloat
+
+    var body: some View {
+        let formattedSpeed = formatCompactByteCount(speed)
+
+        ZStack {
+            Capsule()
+                .fill(backgroundColor)
+
+            HStack(spacing: 5) {
+                Image(systemName: direction.icon)
+                    .font(.system(size: 16, weight: .heavy))
+                    .frame(width: 18)
+
+                HStack(spacing: 2) {
+                    Text(formattedSpeed.value)
+                    Text(formattedSpeed.unit)
+                }
+                .font(.system(size: 25, weight: .bold, design: .monospaced))
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 10)
+        }
+        .frame(width: width, height: 30)
+        .accessibilityLabel("\(direction.helpText), \(formatSpeed(speed))")
+    }
+
+    private var backgroundColor: Color {
+        switch direction {
+        case .download:
+            return Color(red: 0 / 255, green: 116 / 255, blue: 232 / 255)
+        case .upload:
+            return Color(red: 32 / 255, green: 140 / 255, blue: 64 / 255)
+        }
+    }
+}
+#endif

--- a/BitDream/Views/macOS/DockSpeedTileView.swift
+++ b/BitDream/Views/macOS/DockSpeedTileView.swift
@@ -64,8 +64,8 @@ struct DockSpeedTileView: View {
 
     private var accessibilityLabel: String {
         let rates = [
-            content.downloadSpeed.map { "Download speed, \(formatSpeed($0))" },
-            content.uploadSpeed.map { "Upload speed, \(formatSpeed($0))" }
+            content.uploadSpeed.map { "Upload speed, \(formatSpeed($0))" },
+            content.downloadSpeed.map { "Download speed, \(formatSpeed($0))" }
         ].compactMap { $0 }
         return (["BitDream"] + rates).joined(separator: ". ")
     }

--- a/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
+++ b/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
@@ -118,9 +118,9 @@ struct macOSGeneralSettingsTab: View {
                     divider
 
                     settingsSection("Dock Badge") {
-                        Toggle("Completed torrents", isOn: $dockShowCompletedBadge)
-                        Toggle("Total download rate", isOn: $dockShowDownloadSpeed)
-                        Toggle("Total upload rate", isOn: $dockShowUploadSpeed)
+                        Toggle("Show completed torrents count", isOn: $dockShowCompletedBadge)
+                        Toggle("Show download rate", isOn: $dockShowDownloadSpeed)
+                        Toggle("Show upload rate", isOn: $dockShowUploadSpeed)
                     }
 
                     divider

--- a/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
+++ b/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
@@ -12,7 +12,9 @@ struct macOSGeneralSettingsTab: View {
     @AppStorage(UserDefaultsKeys.menuBarShowActiveCount) private var menuBarShowActiveCount: Bool = AppDefaults.menuBarShowActiveCount
     @AppStorage(UserDefaultsKeys.menuBarSortMode) private var menuBarSortModeRaw: String = AppDefaults.menuBarSortMode.rawValue
     @AppStorage(UserDefaultsKeys.startupConnectionBehavior) private var startupBehaviorRaw: String = AppDefaults.startupConnectionBehavior.rawValue
-    @AppStorage(UserDefaultsKeys.dockShowCompletedBadge) private var dockShowCompletedBadge: Bool = AppDefaults.dockShowCompletedBadge
+    @AppStorage(UserDefaultsKeys.dockShowCompletedBadge) private var dockShowCompletedBadge = AppDefaults.dockShowCompletedBadge
+    @AppStorage(UserDefaultsKeys.dockShowDownloadSpeed) private var dockShowDownloadSpeed = AppDefaults.dockShowDownloadSpeed
+    @AppStorage(UserDefaultsKeys.dockShowUploadSpeed) private var dockShowUploadSpeed = AppDefaults.dockShowUploadSpeed
 
     private var menuBarSortMode: Binding<MenuBarSortMode> {
         Binding<MenuBarSortMode>(
@@ -115,6 +117,14 @@ struct macOSGeneralSettingsTab: View {
 
                     divider
 
+                    settingsSection("Dock Badge") {
+                        Toggle("Completed torrents", isOn: $dockShowCompletedBadge)
+                        Toggle("Total download rate", isOn: $dockShowDownloadSpeed)
+                        Toggle("Total upload rate", isOn: $dockShowUploadSpeed)
+                    }
+
+                    divider
+
                     settingsSection("Connection Settings") {
                         HStack {
                             Text("Startup connection")
@@ -161,9 +171,6 @@ struct macOSGeneralSettingsTab: View {
                     divider
 
                     settingsSection("Notifications") {
-                        Toggle("Show Dock badge for completed torrents", isOn: $dockShowCompletedBadge)
-                            .help("Show the number of completed torrents on BitDream's Dock icon.")
-
                         Toggle("Show notifications for completed torrents", isOn: .constant(false))
                             .disabled(true)
 

--- a/BitDreamTests/Formatting/FormattingTests.swift
+++ b/BitDreamTests/Formatting/FormattingTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+@testable import BitDream
+
+final class FormattingTests: XCTestCase {
+
+    // MARK: - formatCompactByteCount
+
+    func testZeroFallsBackToByteUnit() {
+        let components = formatCompactByteCount(0)
+        XCTAssertEqual(components.value, "0")
+        XCTAssertEqual(components.unit, "B")
+    }
+
+    func testSubKilobyteValuesRoundUpToOneKilobyte() {
+        for bytes: Int64 in [1, 500, 999] {
+            let components = formatCompactByteCount(bytes)
+            XCTAssertEqual(components.value, "1", "expected \(bytes) bytes to round up to 1 k")
+            XCTAssertEqual(components.unit, "k")
+        }
+    }
+
+    func testWholeKilobyteValues() {
+        XCTAssertEqual(formatCompactByteCount(1_000).value, "1")
+        XCTAssertEqual(formatCompactByteCount(1_000).unit, "k")
+        XCTAssertEqual(formatCompactByteCount(33_000).value, "33")
+        XCTAssertEqual(formatCompactByteCount(33_000).unit, "k")
+        XCTAssertEqual(formatCompactByteCount(311_000).value, "311")
+        XCTAssertEqual(formatCompactByteCount(311_000).unit, "k")
+    }
+
+    func testRollsOverToMegabytesNearUnitBoundary() {
+        let components = formatCompactByteCount(999_500)
+        XCTAssertEqual(components.value, "1")
+        XCTAssertEqual(components.unit, "M")
+    }
+
+    func testFractionalValuesUseLocaleDecimalSeparator() {
+        let separator = Locale.current.decimalSeparator ?? "."
+        XCTAssertEqual(formatCompactByteCount(1_700_000).value, "1\(separator)7")
+        XCTAssertEqual(formatCompactByteCount(1_700_000).unit, "M")
+    }
+
+    func testLargerUnitSuffixes() {
+        let separator = Locale.current.decimalSeparator ?? "."
+        XCTAssertEqual(formatCompactByteCount(2_500_000_000).value, "2\(separator)5")
+        XCTAssertEqual(formatCompactByteCount(2_500_000_000).unit, "G")
+        XCTAssertEqual(formatCompactByteCount(3_200_000_000_000).value, "3\(separator)2")
+        XCTAssertEqual(formatCompactByteCount(3_200_000_000_000).unit, "T")
+    }
+
+    // MARK: - formatByteCount / formatSpeed
+
+    func testFormatByteCountRoundsSubKilobyteUpToOneKilobyte() {
+        XCTAssertEqual(formatByteCount(500), formatByteCount(1_000))
+    }
+
+    func testFormatSpeedAppendsPerSecondSuffix() {
+        XCTAssertTrue(formatSpeed(33_000).hasSuffix("/s"))
+        XCTAssertTrue(formatSpeed(33_000).hasPrefix(formatByteCount(33_000)))
+    }
+}


### PR DESCRIPTION
## Summary

- add independent General settings for completed torrents, total download rate, and total upload rate on the Dock icon
- render live aggregate transfer rates as accessible, color-coded badges while preserving the native completed-torrent badge
- reuse shared localized byte formatting with compact Dock units and update the tile only when relevant state or preferences change

## Behavior

- transfer-rate badges are disabled by default
- each badge appears only while connected and its corresponding rate is nonzero
- upload appears above download, keeping the primary download badge anchored at the bottom

