### PR TITLE
Add isolated SwiftUI preview infrastructure across iOS and macOS

### DIFF
--- a/BitDream/AppIcon/AppIconManager.swift
+++ b/BitDream/AppIcon/AppIconManager.swift
@@ -11,26 +11,51 @@ final class AppIconManager: ObservableObject {
     @Published var lastError: String?
 
     var supportsAlternateIcons: Bool {
-        UIApplication.shared.supportsAlternateIcons
+        supportsAlternateIconsProvider()
     }
 
     private var foregroundObserver: NSObjectProtocol?
+    private let supportsAlternateIconsProvider: () -> Bool
+    private let currentIconNameProvider: () -> String?
+    private let setAlternateIconName: (String?, @escaping @Sendable (Error?) -> Void) -> Void
 
-    private init() {
-        currentIconName = UIApplication.shared.alternateIconName
-        foregroundObserver = NotificationCenter.default.addObserver(
-            forName: UIApplication.willEnterForegroundNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.refreshCurrentIcon()
+    init(
+        supportsAlternateIcons: @escaping () -> Bool = { UIApplication.shared.supportsAlternateIcons },
+        currentIconName: @escaping () -> String? = { UIApplication.shared.alternateIconName },
+        setAlternateIconName: @escaping (String?, @escaping @Sendable (Error?) -> Void) -> Void = { name, completion in
+            UIApplication.shared.setAlternateIconName(name, completionHandler: completion)
+        },
+        observesApplicationForeground: Bool = true
+    ) {
+        self.supportsAlternateIconsProvider = supportsAlternateIcons
+        self.currentIconNameProvider = currentIconName
+        self.setAlternateIconName = setAlternateIconName
+        self.currentIconName = currentIconName()
+
+        if observesApplicationForeground {
+            foregroundObserver = NotificationCenter.default.addObserver(
+                forName: UIApplication.willEnterForegroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.refreshCurrentIcon()
+                }
             }
         }
     }
 
+    static func inert(currentIconName: String? = nil) -> AppIconManager {
+        AppIconManager(
+            supportsAlternateIcons: { true },
+            currentIconName: { currentIconName },
+            setAlternateIconName: { _, completion in completion(nil) },
+            observesApplicationForeground: false
+        )
+    }
+
     func refreshCurrentIcon() {
-        currentIconName = UIApplication.shared.alternateIconName
+        currentIconName = currentIconNameProvider()
     }
 
     func selectIcon(name: String?) {
@@ -45,7 +70,7 @@ final class AppIconManager: ObservableObject {
         guard currentIconName != name else { return }
 
         isChanging = true
-        UIApplication.shared.setAlternateIconName(name) { [weak self] error in
+        setAlternateIconName(name) { [weak self] error in
             Task { @MainActor in
                 guard let self else { return }
                 self.isChanging = false

--- a/BitDream/AppUpdater.swift
+++ b/BitDream/AppUpdater.swift
@@ -9,37 +9,45 @@ final class AppUpdater: NSObject, ObservableObject {
     @Published private(set) var canCheckForUpdates: Bool = false
     @Published private(set) var lastUpdateCheckDate: Date?
 
-    private lazy var updaterController = SPUStandardUpdaterController(
-        startingUpdater: false,
-        updaterDelegate: self,
-        userDriverDelegate: nil
-    )
+    private var updaterController: SPUStandardUpdaterController?
+    private var disabledAutomaticallyChecksForUpdates = AppUpdater.defaultAutomaticallyChecksForUpdates
 
     private var hasStartedUpdater = false
     private var canCheckObservation: NSKeyValueObservation?
 
     var automaticallyChecksForUpdates: Bool {
-        get { updaterController.updater.automaticallyChecksForUpdates }
-        set { updaterController.updater.automaticallyChecksForUpdates = newValue }
+        get { updaterController?.updater.automaticallyChecksForUpdates ?? disabledAutomaticallyChecksForUpdates }
+        set {
+            if let updaterController {
+                updaterController.updater.automaticallyChecksForUpdates = newValue
+            } else {
+                disabledAutomaticallyChecksForUpdates = newValue
+            }
+        }
     }
 
-    override init() {
+    init(updatesEnabled: Bool = true) {
         super.init()
-        // Force initialization after self is fully initialized.
-        _ = updaterController
+        guard updatesEnabled else { return }
+
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: false,
+            updaterDelegate: self,
+            userDriverDelegate: nil
+        )
         observeUpdaterState()
         refreshState()
     }
 
     func start() {
-        guard !hasStartedUpdater else { return }
+        guard !hasStartedUpdater, let updaterController else { return }
         updaterController.startUpdater()
         hasStartedUpdater = true
         refreshState()
     }
 
     func checkForUpdates() {
-        guard canCheckForUpdates else { return }
+        guard canCheckForUpdates, let updaterController else { return }
         updaterController.checkForUpdates(nil)
     }
 
@@ -48,11 +56,17 @@ final class AppUpdater: NSObject, ObservableObject {
     }
 
     private func refreshState() {
+        guard let updaterController else {
+            canCheckForUpdates = false
+            lastUpdateCheckDate = nil
+            return
+        }
         canCheckForUpdates = updaterController.updater.canCheckForUpdates
         lastUpdateCheckDate = updaterController.updater.lastUpdateCheckDate
     }
 
     private func observeUpdaterState() {
+        guard let updaterController else { return }
         canCheckObservation = updaterController.updater.observe(\.canCheckForUpdates, options: [.initial, .new]) { [weak self] _, change in
             guard let value = change.newValue else { return }
             Task { @MainActor [weak self] in

--- a/BitDream/BitDreamApp.swift
+++ b/BitDream/BitDreamApp.swift
@@ -12,6 +12,9 @@ struct BitDreamApp: App {
     // Create a shared store instance that will be used by both the main app and settings
     @StateObject private var store = TransmissionStore()
     @StateObject private var themeManager = ThemeManager.shared
+    #if os(iOS)
+    @StateObject private var appIconManager = AppIconManager.shared
+    #endif
     #if os(macOS)
     @NSApplicationDelegateAdaptor(AppFileOpenDelegate.self) private var appFileOpenDelegate
     @StateObject private var menuBarStatusItemController = MenuBarStatusItemBridge()
@@ -314,6 +317,7 @@ private extension BitDreamApp {
                 .environmentObject(store) // Pass the shared store to the ContentView
                 .accentColor(themeManager.accentColor) // Apply the accent color to the entire app
                 .environmentObject(themeManager) // Pass the ThemeManager to all views
+                .environmentObject(appIconManager)
                 .immediateTheme(manager: themeManager)
                 .task {
                     await HostRepository.shared.bootstrap()
@@ -352,5 +356,12 @@ private struct AppearanceHUDView: View {
                 .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 4)
         )
     }
+}
+#endif
+
+#if os(macOS) && DEBUG
+#Preview("Appearance HUD", traits: .sizeThatFitsLayout) {
+    AppearanceHUDView(text: "Dark Appearance")
+        .padding()
 }
 #endif

--- a/BitDream/Persistence/AppPreferencesEnvironment.swift
+++ b/BitDream/Persistence/AppPreferencesEnvironment.swift
@@ -1,0 +1,13 @@
+import Foundation
+import SwiftUI
+
+struct HostRepositoryProvider: Sendable {
+    let resolve: @MainActor @Sendable () -> any HostPersisting
+
+    static let live = Self(resolve: { HostRepository.shared })
+}
+
+extension EnvironmentValues {
+    @Entry var appUserDefaults: UserDefaults = .standard
+    @Entry var hostRepositoryProvider: HostRepositoryProvider = .live
+}

--- a/BitDream/PreviewSupport/PreviewSupport.swift
+++ b/BitDream/PreviewSupport/PreviewSupport.swift
@@ -1,0 +1,512 @@
+#if DEBUG
+import SwiftData
+import SwiftUI
+import Observation
+
+@MainActor
+enum PreviewScenario {
+    case empty
+    case connected
+    case reconnecting
+    case error
+}
+
+@MainActor
+@Observable
+final class PreviewEnvironment {
+    let container: ModelContainer
+    let hosts: [Host]
+    let hostRepository: any HostPersisting
+    let store: TransmissionStore
+    let themeManager: ThemeManager
+    let userDefaults: UserDefaults
+    #if os(iOS)
+    let appIconManager: AppIconManager
+    #endif
+    #if os(macOS)
+    let appUpdater: AppUpdater
+    #endif
+
+    init(scenario: PreviewScenario = .connected) {
+        let suiteName = "BitDream.Preview.\(UUID().uuidString)"
+        guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("Unable to create isolated preview preferences.")
+        }
+        let hosts = PreviewFixtures.makeHosts()
+        self.userDefaults = userDefaults
+        self.hosts = hosts
+        self.container = PreviewFixtures.makeModelContainer(hosts: hosts)
+        self.hostRepository = PreviewHostRepository(modelContext: container.mainContext)
+        self.store = PreviewFixtures.makeStore(
+            scenario: scenario,
+            selectedHost: hosts.first,
+            userDefaults: userDefaults
+        )
+        self.themeManager = ThemeManager(userDefaults: userDefaults)
+        #if os(iOS)
+        self.appIconManager = AppIconManager.inert()
+        #endif
+        #if os(macOS)
+        self.appUpdater = AppUpdater(updatesEnabled: false)
+        #endif
+    }
+
+}
+
+@MainActor
+struct PreviewContainer<Content: View>: View {
+    @State private var previewEnvironment: PreviewEnvironment
+    private let content: (PreviewEnvironment) -> Content
+
+    init(
+        scenario: PreviewScenario = .connected,
+        @ViewBuilder content: @escaping (PreviewEnvironment) -> Content
+    ) {
+        _previewEnvironment = State(initialValue: PreviewEnvironment(scenario: scenario))
+        self.content = content
+    }
+
+    var body: some View {
+        configuredContent
+            .modelContainer(previewEnvironment.container)
+            .defaultAppStorage(previewEnvironment.userDefaults)
+            .environment(\.appUserDefaults, previewEnvironment.userDefaults)
+            .environment(
+                \.hostRepositoryProvider,
+                HostRepositoryProvider(resolve: { previewEnvironment.hostRepository })
+            )
+            .environmentObject(previewEnvironment.store)
+            .environmentObject(previewEnvironment.themeManager)
+    }
+
+    @ViewBuilder
+    private var configuredContent: some View {
+        #if os(macOS)
+        content(previewEnvironment)
+            .environmentObject(previewEnvironment.appUpdater)
+        #elseif os(iOS)
+        content(previewEnvironment)
+            .environmentObject(previewEnvironment.appIconManager)
+        #else
+        content(previewEnvironment)
+        #endif
+    }
+}
+
+@MainActor
+private final class PreviewHostRepository: HostPersisting {
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    func bootstrap() async {}
+
+    func create(draft: HostDraft) async throws -> Host {
+        let host = Host(
+            isDefault: draft.isDefault,
+            isSSL: draft.isSSL,
+            name: draft.name,
+            port: Int16(draft.port),
+            server: draft.server,
+            username: draft.username
+        )
+        if draft.isDefault {
+            try clearDefaults(except: nil)
+        }
+        modelContext.insert(host)
+        try modelContext.save()
+        return host
+    }
+
+    func update(serverID: String, draft: HostDraft) async throws -> Host {
+        guard let host = try fetchHost(serverID: serverID) else {
+            throw HostPersistenceError.notFound(serverID)
+        }
+        if draft.isDefault {
+            try clearDefaults(except: serverID)
+        }
+        host.name = draft.name
+        host.server = draft.server
+        host.port = Int16(draft.port)
+        host.username = draft.username
+        host.isSSL = draft.isSSL
+        host.isDefault = draft.isDefault
+        try modelContext.save()
+        return host
+    }
+
+    func delete(serverID: String) async throws {
+        guard let host = try fetchHost(serverID: serverID) else {
+            throw HostPersistenceError.notFound(serverID)
+        }
+        modelContext.delete(host)
+        try modelContext.save()
+    }
+
+    func setDefault(serverID: String) async throws {
+        guard try fetchHost(serverID: serverID) != nil else {
+            throw HostPersistenceError.notFound(serverID)
+        }
+        try clearDefaults(except: serverID)
+        try modelContext.save()
+    }
+
+    func persistVersionIfNeeded(serverID: String, version: String) async {
+        guard let host = try? fetchHost(serverID: serverID), host.version != version else { return }
+        host.version = version
+        try? modelContext.save()
+    }
+
+    func syncCatalog() async {}
+
+    private func fetchHost(serverID: String) throws -> Host? {
+        let descriptor = FetchDescriptor<Host>(
+            predicate: #Predicate<Host> { $0.serverID == serverID }
+        )
+        return try modelContext.fetch(descriptor).first
+    }
+
+    private func clearDefaults(except serverID: String?) throws {
+        let hosts = try modelContext.fetch(FetchDescriptor<Host>())
+        for host in hosts {
+            host.isDefault = host.serverID == serverID
+        }
+    }
+}
+
+@MainActor
+enum PreviewFixtures {
+    static let referenceDate = Date(timeIntervalSince1970: 1_735_689_600)
+
+    static func makeHosts() -> [Host] {
+        [
+            Host(
+                serverID: "preview-home",
+                isDefault: true,
+                isSSL: true,
+                name: "Home Server",
+                port: 9091,
+                server: "transmission.example.com",
+                username: "preview",
+                version: "4.0.6"
+            ),
+            Host(
+                serverID: "preview-remote",
+                name: "Remote Seedbox",
+                port: 9091,
+                server: "seedbox.example.com",
+                username: "preview",
+                version: "4.0.6"
+            )
+        ]
+    }
+
+    static func makeModelContainer(hosts: [Host] = makeHosts()) -> ModelContainer {
+        let schema = Schema([Host.self])
+        let configuration = ModelConfiguration(
+            "bitdream.preview.hosts",
+            schema: schema,
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: .none
+        )
+
+        do {
+            let container = try ModelContainer(for: schema, configurations: [configuration])
+            hosts.forEach(container.mainContext.insert)
+            try container.mainContext.save()
+            return container
+        } catch {
+            preconditionFailure("Unable to create the preview model container: \(error)")
+        }
+    }
+
+    static func makeStore(
+        scenario: PreviewScenario = .connected,
+        selectedHost: Host? = makeHosts().first,
+        userDefaults: UserDefaults = .standard
+    ) -> TransmissionStore {
+        let store = TransmissionStore(
+            resolveConnection: { _ in
+                throw TransmissionError.transport(
+                    underlyingDescription: "Networking is disabled in previews."
+                )
+            },
+            snapshotWriter: WidgetSnapshotWriter(
+                writeServerIndex: { _ in },
+                writeSessionSnapshot: { _, _, _, _, _ in },
+                reloadTimelines: {}
+            ),
+            monotonicTime: { 0 },
+            userDefaults: userDefaults,
+            automaticallyRetriesConnection: false,
+            updateBackgroundActivityInterval: { _ in },
+            persistVersion: { _, _ in }
+        )
+
+        switch scenario {
+        case .empty:
+            break
+        case .connected:
+            store.host = selectedHost
+            store.torrents = torrents
+            store.sessionStats = sessionStats
+            store.sessionConfiguration = sessionConfiguration
+            store.defaultDownloadDir = "/Volumes/Downloads"
+            store.connectionStatus = .connected
+            store.lastRefreshAt = referenceDate
+        case .reconnecting:
+            store.host = selectedHost
+            store.torrents = torrents
+            store.sessionStats = sessionStats
+            store.connectionStatus = .reconnecting
+            store.lastErrorMessage = "The server is temporarily unavailable."
+            store.nextRetryAt = referenceDate.addingTimeInterval(15)
+        case .error:
+            store.host = selectedHost
+            store.torrents = torrents
+            store.connectionStatus = .reconnecting
+            store.isError = true
+            store.debugBrief = "Unable to connect"
+            store.debugMessage = "The preview server rejected the connection."
+            store.lastErrorMessage = store.debugMessage
+        }
+
+        return store
+    }
+}
+
+@MainActor
+extension PreviewFixtures {
+    static let torrents: [Torrent] = [
+        torrent(
+            id: 1,
+            name: "Ubuntu 26.04 Desktop",
+            status: .downloading,
+            percentDone: 0.64,
+            labels: ["Linux", "ISO"],
+            rateDownload: 18_400_000,
+            rateUpload: 420_000,
+            peersConnected: 24,
+            eta: 1_245
+        ),
+        torrent(
+            id: 2,
+            name: "Big Buck Bunny",
+            status: .seeding,
+            percentDone: 1,
+            labels: ["Movies"],
+            rateUpload: 5_200_000,
+            peersConnected: 8,
+            uploadRatio: 2.34
+        ),
+        torrent(
+            id: 3,
+            name: "Public Domain Audiobooks Collection",
+            status: .stopped,
+            percentDone: 0.27,
+            labels: [],
+            isStalled: false
+        ),
+        torrent(
+            id: 4,
+            name: "Open Source Archive",
+            status: .downloading,
+            percentDone: 0.81,
+            labels: ["Archive", "Long-term storage"],
+            isStalled: true,
+            error: TorrentError.trackerWarning.rawValue,
+            errorString: "Tracker has not responded yet"
+        ),
+        torrent(
+            id: 5,
+            name: "Completed Sample",
+            status: .stopped,
+            percentDone: 1,
+            labels: ["Complete"],
+            uploadRatio: 1.1
+        )
+    ]
+
+    static func torrent(
+        id: Int,
+        name: String,
+        status: TorrentStatus,
+        percentDone: Double,
+        labels: [String],
+        rateDownload: Int64 = 0,
+        rateUpload: Int64 = 0,
+        peersConnected: Int = 0,
+        eta: Int = -1,
+        isStalled: Bool = false,
+        error: Int = TorrentError.none.rawValue,
+        errorString: String = "",
+        uploadRatio: Double = 0.42
+    ) -> Torrent {
+        let totalSize: Int64 = 8_000_000_000
+        let downloaded = Int64(Double(totalSize) * percentDone)
+        return Torrent(
+            activityDate: Int(referenceDate.timeIntervalSince1970),
+            addedDate: Int(referenceDate.addingTimeInterval(-86_400).timeIntervalSince1970),
+            desiredAvailable: totalSize - downloaded,
+            error: error,
+            errorString: errorString,
+            eta: eta,
+            haveUnchecked: 0,
+            haveValid: downloaded,
+            id: id,
+            isFinished: percentDone == 1,
+            isStalled: isStalled,
+            labels: labels,
+            leftUntilDone: totalSize - downloaded,
+            magnetLink: "magnet:?xt=urn:btih:preview-\(id)",
+            metadataPercentComplete: 1,
+            name: name,
+            peersConnected: peersConnected,
+            peersGettingFromUs: status == .seeding ? peersConnected : 0,
+            peersSendingToUs: status == .downloading ? peersConnected : 0,
+            percentDone: percentDone,
+            primaryMimeType: "application/octet-stream",
+            downloadDir: "/Volumes/Downloads",
+            queuePosition: id - 1,
+            rateDownload: rateDownload,
+            rateUpload: rateUpload,
+            sizeWhenDone: totalSize,
+            status: status.rawValue,
+            totalSize: totalSize,
+            uploadRatioRaw: uploadRatio,
+            uploadedEver: Int64(Double(totalSize) * uploadRatio),
+            downloadedEver: downloaded
+        )
+    }
+
+    static let sessionStats = SessionStats(
+        activeTorrentCount: 3,
+        downloadSpeed: 18_400_000,
+        pausedTorrentCount: 1,
+        torrentCount: torrents.count,
+        uploadSpeed: 5_620_000,
+        cumulativeStats: TransmissionCumulativeStats(
+            downloadedBytes: 4_800_000_000_000,
+            filesAdded: 412,
+            secondsActive: 31_536_000,
+            sessionCount: 86,
+            uploadedBytes: 7_200_000_000_000
+        ),
+        currentStats: TransmissionCumulativeStats(
+            downloadedBytes: 48_000_000_000,
+            filesAdded: 8,
+            secondsActive: 86_400,
+            sessionCount: 1,
+            uploadedBytes: 72_000_000_000
+        )
+    )
+
+    static let files: [TorrentFile] = [
+        TorrentFile(bytesCompleted: 3_200_000_000, length: 5_000_000_000, name: "Ubuntu 26.04/ubuntu-26.04.iso"),
+        TorrentFile(bytesCompleted: 2_048, length: 2_048, name: "Ubuntu 26.04/README.txt"),
+        TorrentFile(bytesCompleted: 0, length: 4_096, name: "Ubuntu 26.04/CHECKSUMS")
+    ]
+
+    static let fileStats: [TorrentFileStats] = [
+        TorrentFileStats(bytesCompleted: 3_200_000_000, wanted: true, priority: FilePriority.high.rawValue),
+        TorrentFileStats(bytesCompleted: 2_048, wanted: true, priority: FilePriority.normal.rawValue),
+        TorrentFileStats(bytesCompleted: 0, wanted: false, priority: FilePriority.low.rawValue)
+    ]
+
+    static let peers: [Peer] = [
+        Peer(
+            address: "203.0.113.10",
+            clientName: "Transmission 4.0.6",
+            clientIsChoked: false,
+            clientIsInterested: true,
+            flagStr: "UTEP",
+            isDownloadingFrom: true,
+            isEncrypted: true,
+            isIncoming: false,
+            isUploadingTo: false,
+            isUTP: true,
+            peerIsChoked: false,
+            peerIsInterested: true,
+            port: 51_413,
+            progress: 0.72,
+            rateToClient: 2_400_000,
+            rateToPeer: 120_000
+        ),
+        Peer(
+            address: "2001:db8::42",
+            clientName: "qBittorrent 5.0",
+            clientIsChoked: false,
+            clientIsInterested: false,
+            flagStr: "DE",
+            isDownloadingFrom: false,
+            isEncrypted: true,
+            isIncoming: true,
+            isUploadingTo: true,
+            isUTP: false,
+            peerIsChoked: false,
+            peerIsInterested: true,
+            port: 68_81,
+            progress: 1,
+            rateToClient: 0,
+            rateToPeer: 860_000
+        )
+    ]
+
+    static let peersFrom = PeersFrom(
+        fromCache: 1,
+        fromDht: 8,
+        fromIncoming: 2,
+        fromLpd: 0,
+        fromLtep: 1,
+        fromPex: 12,
+        fromTracker: 4
+    )
+
+    static let sessionConfiguration = TransmissionSessionResponseArguments(
+        downloadDir: "/Volumes/Downloads",
+        version: "4.0.6",
+        speedLimitDown: 50_000,
+        speedLimitDownEnabled: false,
+        speedLimitUp: 10_000,
+        speedLimitUpEnabled: true,
+        altSpeedDown: 5_000,
+        altSpeedUp: 1_000,
+        altSpeedEnabled: false,
+        altSpeedTimeBegin: 480,
+        altSpeedTimeEnd: 1_020,
+        altSpeedTimeEnabled: true,
+        altSpeedTimeDay: 127,
+        incompleteDir: "/Volumes/Downloads/Incomplete",
+        incompleteDirEnabled: true,
+        startAddedTorrents: true,
+        trashOriginalTorrentFiles: false,
+        renamePartialFiles: true,
+        downloadQueueEnabled: true,
+        downloadQueueSize: 5,
+        seedQueueEnabled: true,
+        seedQueueSize: 10,
+        seedRatioLimited: true,
+        seedRatioLimit: 2,
+        idleSeedingLimit: 30,
+        idleSeedingLimitEnabled: false,
+        queueStalledEnabled: true,
+        queueStalledMinutes: 30,
+        peerPort: 51_413,
+        peerPortRandomOnStart: false,
+        portForwardingEnabled: true,
+        dhtEnabled: true,
+        pexEnabled: true,
+        lpdEnabled: false,
+        encryption: "preferred",
+        utpEnabled: true,
+        peerLimitGlobal: 200,
+        peerLimitPerTorrent: 50,
+        blocklistEnabled: true,
+        blocklistSize: 124_806,
+        blocklistUrl: "https://example.com/blocklist",
+        defaultTrackers: ""
+    )
+}
+#endif

--- a/BitDream/ThemeManager.swift
+++ b/BitDream/ThemeManager.swift
@@ -49,17 +49,19 @@ final class ThemeManager: ObservableObject {
     // Keys for storing preferences
     private let accentColorKey = "accentColorKey"
     private let themeModeKey = "themeModeKey"
+    private let userDefaults: UserDefaults
 
-    init() {
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
         // Load saved accent color from UserDefaults or use default
-        let savedHex = UserDefaults.standard.string(forKey: accentColorKey) ?? AccentColorOption.defaultColor.rawValue
+        let savedHex = userDefaults.string(forKey: accentColorKey) ?? AccentColorOption.defaultColor.rawValue
 
         // Initialize with default values first
         self.currentAccentColorOption = .blue
         self.accentColor = Color(hex: AccentColorOption.defaultColor.rawValue)
 
         // Load saved theme mode or use system default
-        if let savedThemeMode = UserDefaults.standard.string(forKey: themeModeKey),
+        if let savedThemeMode = userDefaults.string(forKey: themeModeKey),
            let mode = ThemeMode(rawValue: savedThemeMode) {
             self.themeMode = mode
         } else {
@@ -78,14 +80,14 @@ final class ThemeManager: ObservableObject {
         self.accentColor = option.color
 
         // Save to UserDefaults
-        UserDefaults.standard.set(option.rawValue, forKey: accentColorKey)
+        userDefaults.set(option.rawValue, forKey: accentColorKey)
     }
 
     func setThemeMode(_ mode: ThemeMode) {
         self.themeMode = mode
 
         // Save to UserDefaults
-        UserDefaults.standard.set(mode.rawValue, forKey: themeModeKey)
+        userDefaults.set(mode.rawValue, forKey: themeModeKey)
     }
 
     func cycleThemeMode() {
@@ -117,7 +119,7 @@ final class ThemeManager: ObservableObject {
         } else {
             // If hex doesn't match any predefined option, create a custom color
             self.accentColor = Color(hex: hex)
-            UserDefaults.standard.set(hex, forKey: accentColorKey)
+            userDefaults.set(hex, forKey: accentColorKey)
         }
     }
 }

--- a/BitDream/TransmissionStore.swift
+++ b/BitDream/TransmissionStore.swift
@@ -118,7 +118,7 @@ final class TransmissionStore: NSObject, ObservableObject {
     @Published var pollInterval: Double = AppDefaults.pollInterval // Default poll interval in seconds
     @Published var shouldActivateSearch: Bool = false
     @Published var shouldToggleInspector: Bool = false
-    @Published var isInspectorVisible: Bool = UserDefaults.standard.inspectorVisibility
+    @Published var isInspectorVisible: Bool
 
 #if os(macOS)
     // Controls how the Add Torrent flow should start when invoked from menu
@@ -148,6 +148,9 @@ final class TransmissionStore: NSObject, ObservableObject {
     private let monotonicTime: @Sendable () -> TimeInterval
     private let torrentDetailRefreshInterval: TimeInterval
     private let persistVersion: @MainActor @Sendable (String, String) async -> Void
+    private let userDefaults: UserDefaults
+    private let automaticallyRetriesConnection: Bool
+    private let updateBackgroundActivityInterval: @MainActor @Sendable (Double) -> Void
 
     private var activeConnection: ActiveConnection?
     private var activationFailure: ActivationFailure?
@@ -175,6 +178,13 @@ final class TransmissionStore: NSObject, ObservableObject {
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void = TransmissionStore.liveSleep,
         monotonicTime: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
         torrentDetailRefreshInterval: TimeInterval = AppDefaults.torrentDetailRefreshInterval,
+        userDefaults: UserDefaults = .standard,
+        automaticallyRetriesConnection: Bool = true,
+        updateBackgroundActivityInterval: @escaping @MainActor @Sendable (Double) -> Void = { interval in
+            #if os(macOS)
+            BackgroundActivityScheduler.updateInterval(interval)
+            #endif
+        },
         persistVersion: @escaping @MainActor @Sendable (String, String) async -> Void = { serverID, version in
             await HostRepository.shared.persistVersionIfNeeded(serverID: serverID, version: version)
         }
@@ -193,10 +203,14 @@ final class TransmissionStore: NSObject, ObservableObject {
         self.sleep = sleep
         self.monotonicTime = monotonicTime
         self.torrentDetailRefreshInterval = max(1, torrentDetailRefreshInterval)
+        self.userDefaults = userDefaults
+        self.automaticallyRetriesConnection = automaticallyRetriesConnection
+        self.updateBackgroundActivityInterval = updateBackgroundActivityInterval
         self.persistVersion = persistVersion
+        self.isInspectorVisible = userDefaults.inspectorVisibility
         super.init()
         // Load persisted poll interval if available
-        if let saved = UserDefaults.standard.object(forKey: UserDefaultsKeys.pollInterval) as? Double {
+        if let saved = userDefaults.object(forKey: UserDefaultsKeys.pollInterval) as? Double {
             self.pollInterval = max(1.0, saved)
         } else {
             self.pollInterval = AppDefaults.pollInterval
@@ -574,6 +588,11 @@ extension TransmissionStore {
             cancelPollTask()
         }
 
+        guard automaticallyRetriesConnection else {
+            clearReconnectPresentationState()
+            return
+        }
+
         if let nextRetryAt, nextRetryAt > now {
             if retryTask == nil {
                 let remainingDelay = nextRetryAt.timeIntervalSince(now)
@@ -590,16 +609,13 @@ extension TransmissionStore {
     // Add a method to update the poll interval and restart the timer
     func updatePollInterval(_ newInterval: Double) {
         pollInterval = max(1.0, newInterval)
-        UserDefaults.standard.set(pollInterval, forKey: UserDefaultsKeys.pollInterval)
+        userDefaults.set(pollInterval, forKey: UserDefaultsKeys.pollInterval)
 
         if let activeConnection, connectionStatus == .connected {
             startPolling(for: activeConnection)
         }
 
-        // Update the macOS background scheduler with new interval
-        #if os(macOS)
-        BackgroundActivityScheduler.updateInterval(newInterval)
-        #endif
+        updateBackgroundActivityInterval(newInterval)
     }
 
     func clearSelectedHost() {
@@ -624,6 +640,10 @@ extension TransmissionStore {
         lastRefreshAt = nil
         lastErrorMessage = ""
         connectionStatus = .connecting
+    }
+
+    func clearPersistedSelectedHost() {
+        userDefaults.removeObject(forKey: UserDefaultsKeys.selectedHost)
     }
 
     // MARK: - Label Management
@@ -703,7 +723,7 @@ extension TransmissionStore {
         markConnecting()
         self.host = host
         activeConnection = nil
-        UserDefaults.standard.set(host.serverID, forKey: UserDefaultsKeys.selectedHost)
+        userDefaults.set(host.serverID, forKey: UserDefaultsKeys.selectedHost)
         clearReconnectPresentationState()
         if trigger.resetsReconnectBackoff {
             resetReconnectBackoff()

--- a/BitDream/Views/Shared/AddTorrent.swift
+++ b/BitDream/Views/Shared/AddTorrent.swift
@@ -16,6 +16,14 @@ struct AddTorrent: View {
     }
 }
 
+#if DEBUG
+#Preview("Add Torrent") {
+    PreviewContainer { environment in
+        AddTorrent(store: environment.store)
+    }
+}
+#endif
+
 // MARK: - Shared Helper Functions
 
 /// Function to handle errors in the torrent adding process

--- a/BitDream/Views/Shared/ContentView.swift
+++ b/BitDream/Views/Shared/ContentView.swift
@@ -68,6 +68,7 @@ extension UserDefaults {
 }
 
 struct ContentView: View {
+    @Environment(\.appUserDefaults) private var userDefaults
     @Query(sort: \Host.name, order: .forward) private var hosts: [Host]
 
     // Use the store passed from the environment
@@ -75,9 +76,9 @@ struct ContentView: View {
 
     var body: some View {
         #if os(iOS)
-        iOSContentView(hosts: hosts, store: store)
+        iOSContentView(hosts: hosts, store: store, userDefaults: userDefaults)
         #elseif os(macOS)
-        macOSContentView(hosts: hosts, store: store)
+        macOSContentView(hosts: hosts, store: store, userDefaults: userDefaults)
         #endif
     }
 }
@@ -178,8 +179,8 @@ func makeRatioSummarySnapshot(store: TransmissionStore, displayMode: RatioDispla
 
 // Stats header view used on both platforms
 struct StatsHeaderView: View {
+    @EnvironmentObject private var themeManager: ThemeManager
     @ObservedObject var store: TransmissionStore
-    @ObservedObject private var themeManager = ThemeManager.shared
     @AppStorage(UserDefaultsKeys.ratioDisplayMode) private var ratioDisplayModeRaw: String = AppDefaults.ratioDisplayMode.rawValue
 
     // MARK: - Computed totals and ratio
@@ -246,6 +247,21 @@ struct StatsHeaderView: View {
         .padding(.vertical, 8)
     }
 }
+
+#if DEBUG
+#Preview("Content — Connected") {
+    PreviewContainer { _ in
+        ContentView()
+    }
+}
+
+#Preview("Statistics Header", traits: .sizeThatFitsLayout) {
+    PreviewContainer { environment in
+        StatsHeaderView(store: environment.store)
+            .padding()
+    }
+}
+#endif
 
 // MARK: - Shared Enums
 

--- a/BitDream/Views/Shared/ErrorDialog.swift
+++ b/BitDream/Views/Shared/ErrorDialog.swift
@@ -33,3 +33,11 @@ struct ErrorDialog: View {
         }
     }
 }
+
+#if DEBUG
+#Preview("Error Dialog", traits: .fixedLayout(width: 420, height: 320)) {
+    PreviewContainer(scenario: .error) { environment in
+        ErrorDialog(store: environment.store)
+    }
+}
+#endif

--- a/BitDream/Views/Shared/PiecesGridView.swift
+++ b/BitDream/Views/Shared/PiecesGridView.swift
@@ -93,3 +93,10 @@ private func computeColumns(availableWidth: CGFloat, cellSize: CGFloat, cellSpac
     // Ensure at least 8 columns for visual density; width-bounded so it won't overflow
     return max(8, Int(floor((availableWidth + cellSpacing) / unit)))
 }
+
+#if DEBUG
+#Preview("Pieces Grid", traits: .fixedLayout(width: 420, height: 100)) {
+    PiecesGridView(piecesHaveSet: (0..<256).map { $0 % 5 != 0 }, rows: 8)
+        .padding()
+}
+#endif

--- a/BitDream/Views/Shared/ServerActions.swift
+++ b/BitDream/Views/Shared/ServerActions.swift
@@ -75,7 +75,7 @@ private func completeServerDeletion(host: Host, store: TransmissionStore, hosts:
     if let nextHost = hosts.first(where: { $0.serverID != host.serverID }) {
         store.setHost(host: nextHost)
     } else {
-        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedHost)
+        store.clearPersistedSelectedHost()
         store.clearSelectedHost()
     }
 }

--- a/BitDream/Views/Shared/ServerRowLabel.swift
+++ b/BitDream/Views/Shared/ServerRowLabel.swift
@@ -43,3 +43,13 @@ struct ServerRowLabel: View {
         return "\(host.displayName), \(host.server ?? "Unknown host"), port \(host.port)\(defaultLabel)\(connectedLabel)"
     }
 }
+
+#if DEBUG
+#Preview("Server Row", traits: .sizeThatFitsLayout) {
+    PreviewContainer { environment in
+        ServerRowLabel(host: environment.hosts[0], isConnected: true)
+            .padding()
+            .frame(width: 420)
+    }
+}
+#endif

--- a/BitDream/Views/Shared/Settings/NetworkSettings.swift
+++ b/BitDream/Views/Shared/Settings/NetworkSettings.swift
@@ -238,3 +238,11 @@ struct NetworkContent: View {
         }
     }
 }
+
+#if DEBUG
+#Preview("Network Settings", traits: .fixedLayout(width: 700, height: 720)) {
+    @Previewable @StateObject var editModel = SettingsViewModel()
+    NetworkContent(config: PreviewFixtures.sessionConfiguration, editModel: editModel)
+        .padding()
+}
+#endif

--- a/BitDream/Views/Shared/Settings/SettingsView.swift
+++ b/BitDream/Views/Shared/Settings/SettingsView.swift
@@ -5,6 +5,8 @@ import Foundation
 /// This view simply delegates to the appropriate platform-specific implementation
 struct SettingsView: View {
     @ObservedObject var store: TransmissionStore
+    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.appUserDefaults) private var userDefaults
 
     // Shared poll interval options
     static let pollIntervalOptions: [Double] = [1.0, 2.0, 5.0, 10.0, 30.0, 60.0]
@@ -21,20 +23,24 @@ struct SettingsView: View {
     }
 
     // Shared reset for both platforms
-    static func resetAllSettings(store: TransmissionStore, afterReset: () -> Void = {}) {
-        let theme = ThemeManager.shared
-        theme.setAccentColor(AppDefaults.accentColor)
-        theme.setThemeMode(AppDefaults.themeMode)
+    static func resetAllSettings(
+        store: TransmissionStore,
+        themeManager: ThemeManager = .shared,
+        userDefaults: UserDefaults = .standard,
+        afterReset: () -> Void = {}
+    ) {
+        themeManager.setAccentColor(AppDefaults.accentColor)
+        themeManager.setThemeMode(AppDefaults.themeMode)
 
         // Persist AppStorage-backed flags
-        UserDefaults.standard.set(AppDefaults.showContentTypeIcons, forKey: UserDefaultsKeys.showContentTypeIcons)
-        UserDefaults.standard.set(AppDefaults.menuBarTransferWidgetEnabled, forKey: UserDefaultsKeys.menuBarTransferWidgetEnabled)
-        UserDefaults.standard.set(AppDefaults.menuBarShowActiveCount, forKey: UserDefaultsKeys.menuBarShowActiveCount)
-        UserDefaults.standard.set(AppDefaults.menuBarSortMode.rawValue, forKey: UserDefaultsKeys.menuBarSortMode)
-        UserDefaults.standard.set(AppDefaults.dockShowCompletedBadge, forKey: UserDefaultsKeys.dockShowCompletedBadge)
-        UserDefaults.standard.set(AppDefaults.dockShowDownloadSpeed, forKey: UserDefaultsKeys.dockShowDownloadSpeed)
-        UserDefaults.standard.set(AppDefaults.dockShowUploadSpeed, forKey: UserDefaultsKeys.dockShowUploadSpeed)
-        UserDefaults.standard.set(AppDefaults.startupConnectionBehavior.rawValue, forKey: UserDefaultsKeys.startupConnectionBehavior)
+        userDefaults.set(AppDefaults.showContentTypeIcons, forKey: UserDefaultsKeys.showContentTypeIcons)
+        userDefaults.set(AppDefaults.menuBarTransferWidgetEnabled, forKey: UserDefaultsKeys.menuBarTransferWidgetEnabled)
+        userDefaults.set(AppDefaults.menuBarShowActiveCount, forKey: UserDefaultsKeys.menuBarShowActiveCount)
+        userDefaults.set(AppDefaults.menuBarSortMode.rawValue, forKey: UserDefaultsKeys.menuBarSortMode)
+        userDefaults.set(AppDefaults.dockShowCompletedBadge, forKey: UserDefaultsKeys.dockShowCompletedBadge)
+        userDefaults.set(AppDefaults.dockShowDownloadSpeed, forKey: UserDefaultsKeys.dockShowDownloadSpeed)
+        userDefaults.set(AppDefaults.dockShowUploadSpeed, forKey: UserDefaultsKeys.dockShowUploadSpeed)
+        userDefaults.set(AppDefaults.startupConnectionBehavior.rawValue, forKey: UserDefaultsKeys.startupConnectionBehavior)
 
         // Poll interval via TransmissionStore API
         store.updatePollInterval(AppDefaults.pollInterval)
@@ -43,6 +49,8 @@ struct SettingsView: View {
 
     var body: some View {
         PlatformSettingsView(store: store)
+            .environmentObject(themeManager)
+            .environment(\.appUserDefaults, userDefaults)
     }
 }
 
@@ -60,6 +68,10 @@ extension Binding where Value == StartupConnectionBehavior {
     }
 }
 
-#Preview {
-    SettingsView(store: TransmissionStore())
+#if DEBUG
+#Preview("Platform Settings") {
+    PreviewContainer { environment in
+        SettingsView(store: environment.store)
+    }
 }
+#endif

--- a/BitDream/Views/Shared/Settings/SettingsViewModel.swift
+++ b/BitDream/Views/Shared/Settings/SettingsViewModel.swift
@@ -123,6 +123,16 @@ struct SettingsSaveStateView: View {
     }
 }
 
+#if DEBUG
+#Preview("Settings Save States", traits: .sizeThatFitsLayout) {
+    VStack(alignment: .leading, spacing: 12) {
+        SettingsSaveStateView(state: .pending)
+        SettingsSaveStateView(state: .saving)
+    }
+    .padding()
+}
+#endif
+
 extension View {
     @MainActor
     func bindSettingsViewModel(

--- a/BitDream/Views/Shared/Settings/SpeedLimitsSettings.swift
+++ b/BitDream/Views/Shared/Settings/SpeedLimitsSettings.swift
@@ -166,3 +166,11 @@ struct SpeedLimitsContent: View {
         }
     }
 }
+
+#if DEBUG
+#Preview("Speed Limit Settings", traits: .fixedLayout(width: 700, height: 620)) {
+    @Previewable @StateObject var editModel = SettingsViewModel()
+    SpeedLimitsContent(config: PreviewFixtures.sessionConfiguration, editModel: editModel)
+        .padding()
+}
+#endif

--- a/BitDream/Views/Shared/Settings/TorrentSettings.swift
+++ b/BitDream/Views/Shared/Settings/TorrentSettings.swift
@@ -213,3 +213,17 @@ struct SeedingContent: View {
         }
     }
 }
+
+#if DEBUG
+#Preview("Torrent Settings", traits: .fixedLayout(width: 700, height: 760)) {
+    @Previewable @StateObject var editModel = SettingsViewModel()
+    ScrollView {
+        VStack(alignment: .leading, spacing: 24) {
+            FileManagementContent(config: PreviewFixtures.sessionConfiguration, editModel: editModel)
+            QueueManagementContent(config: PreviewFixtures.sessionConfiguration, editModel: editModel)
+            SeedingContent(config: PreviewFixtures.sessionConfiguration, editModel: editModel)
+        }
+        .padding()
+    }
+}
+#endif

--- a/BitDream/Views/Shared/SharedComponents.swift
+++ b/BitDream/Views/Shared/SharedComponents.swift
@@ -203,3 +203,17 @@ extension View {
         }
     }
 }
+
+#if DEBUG
+#Preview("Shared Transfer Components", traits: .sizeThatFitsLayout) {
+    VStack(alignment: .leading, spacing: 12) {
+        HStack {
+            SpeedChip(speed: 18_400_000, direction: .download)
+            SpeedChip(speed: 5_620_000, direction: .upload)
+            RatioChip(ratio: 1.5)
+        }
+        FileProgressView(percentDone: 0.64, showDetailedText: true)
+    }
+    .padding()
+}
+#endif

--- a/BitDream/Views/Shared/TorrentDetail.swift
+++ b/BitDream/Views/Shared/TorrentDetail.swift
@@ -775,6 +775,14 @@ struct DetailViewLabelTag: View {
     }
 }
 
+#if DEBUG
+#Preview("Torrent Detail") {
+    PreviewContainer { environment in
+        TorrentDetail(store: environment.store, torrent: PreviewFixtures.torrents[0])
+    }
+}
+#endif
+
 private func formatTorrentDetailDate(_ timestamp: Int) -> String {
     let date = Date(timeIntervalSince1970: Double(timestamp))
     return date.formatted(

--- a/BitDream/Views/Shared/TorrentFileDetail.swift
+++ b/BitDream/Views/Shared/TorrentFileDetail.swift
@@ -229,27 +229,6 @@ func applyLocalFilePriority(
     return result
 }
 
-// MARK: - Preview Data
-
-/// Shared test data for previews
-struct TorrentFilePreviewData {
-    static let sampleFiles: [TorrentFile] = [
-        TorrentFile(bytesCompleted: 1024 * 1024 * 50, length: 1024 * 1024 * 100, name: "Movie.2024/Movie.2024.mkv"),
-        TorrentFile(bytesCompleted: 1024 * 1024 * 25, length: 1024 * 1024 * 25, name: "Movie.2024/Subtitles/English.srt"),
-        TorrentFile(bytesCompleted: 1024 * 1024 * 75, length: 1024 * 1024 * 200, name: "Movie.2024/extras/behind_scenes.mp4"),
-        TorrentFile(bytesCompleted: 0, length: 1024 * 1024 * 10, name: "Movie.2024/poster.jpg"),
-        TorrentFile(bytesCompleted: 0, length: 1024 * 1024 * 50, name: "Movie.2024/soundtrack.mp3")
-    ]
-
-    static let sampleFileStats: [TorrentFileStats] = [
-        TorrentFileStats(bytesCompleted: 1024 * 1024 * 50, wanted: true, priority: -1),  // Low priority
-        TorrentFileStats(bytesCompleted: 1024 * 1024 * 25, wanted: true, priority: 0),   // Normal priority
-        TorrentFileStats(bytesCompleted: 1024 * 1024 * 75, wanted: true, priority: 1),   // High priority
-        TorrentFileStats(bytesCompleted: 0, wanted: true, priority: -1),                 // Low priority
-        TorrentFileStats(bytesCompleted: 0, wanted: false, priority: -1)                 // Unwanted file with low priority
-    ]
-}
-
 // MARK: - Shared Components
 
 /// Priority badge component for consistent styling across platforms
@@ -312,6 +291,28 @@ struct FileTypeChip: View {
         .cornerRadius(4)
     }
 }
+
+#if DEBUG
+#Preview("Torrent File Detail") {
+    PreviewContainer { environment in
+        TorrentFileDetail(
+            files: PreviewFixtures.files,
+            fileStats: PreviewFixtures.fileStats,
+            torrentId: PreviewFixtures.torrents[0].id,
+            store: environment.store
+        )
+    }
+}
+
+#Preview("File Badges", traits: .sizeThatFitsLayout) {
+    HStack {
+        PriorityBadge(priority: .high)
+        StatusBadge(wanted: false)
+        FileTypeChip(filename: "ubuntu-26.04.iso")
+    }
+    .padding()
+}
+#endif
 
 // FileProgressView moved to SharedComponents.swift
 

--- a/BitDream/Views/Shared/TorrentListRow.swift
+++ b/BitDream/Views/Shared/TorrentListRow.swift
@@ -230,6 +230,20 @@ struct LabelTag: View {
     }
 }
 
+#if DEBUG
+#Preview("Torrent List Row", traits: .fixedLayout(width: 700, height: 110)) {
+    PreviewContainer { environment in
+        TorrentListRow(
+            torrent: PreviewFixtures.torrents[0],
+            store: environment.store,
+            selectedTorrents: [PreviewFixtures.torrents[0]],
+            showContentTypeIcons: true
+        )
+        .padding()
+    }
+}
+#endif
+
 // Shared function to create label tags view
 @MainActor
 func createLabelTagsView(for torrent: Torrent) -> some View {

--- a/BitDream/Views/Shared/TorrentPeerDetail.swift
+++ b/BitDream/Views/Shared/TorrentPeerDetail.swift
@@ -35,6 +35,17 @@ struct BoolCheckIcon: View {
     }
 }
 
+#if DEBUG
+#Preview("Peer Badges", traits: .sizeThatFitsLayout) {
+    HStack {
+        ProtocolBadge(text: "uTP")
+        BoolCheckIcon(value: true, label: "Encrypted")
+        BoolCheckIcon(value: false, label: "Incoming")
+    }
+    .padding()
+}
+#endif
+
 // MARK: - Shared Peer Helpers
 
 /// Build a user-friendly help/tooltip text for a peer's state flags

--- a/BitDream/Views/Shared/TransmissionActions.swift
+++ b/BitDream/Views/Shared/TransmissionActions.swift
@@ -213,3 +213,15 @@ extension View {
         modifier(TransmissionErrorAlert(isPresented: isPresented, message: message))
     }
 }
+
+#if DEBUG
+#Preview("Transmission Error Alert", traits: .sizeThatFitsLayout) {
+    @Previewable @State var isPresented = true
+    Button("Show Error") { isPresented = true }
+        .transmissionErrorAlert(
+            isPresented: $isPresented,
+            message: "The preview server is unavailable."
+        )
+        .padding()
+}
+#endif

--- a/BitDream/Views/iOS/Settings/iOSAboutView.swift
+++ b/BitDream/Views/iOS/Settings/iOSAboutView.swift
@@ -92,10 +92,13 @@ struct iOSAboutView: View {
     }
 }
 
-#Preview {
-    NavigationView {
-        iOSAboutView()
-            .environmentObject(ThemeManager.shared)
+#if DEBUG
+#Preview("iOS About") {
+    PreviewContainer { _ in
+        NavigationStack {
+            iOSAboutView()
+        }
     }
 }
+#endif
 #endif

--- a/BitDream/Views/iOS/Settings/iOSNetworkSettingsView.swift
+++ b/BitDream/Views/iOS/Settings/iOSNetworkSettingsView.swift
@@ -198,3 +198,13 @@ struct iOSNetworkSettingsView: View {
     }
 }
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Network Settings") {
+    PreviewContainer { environment in
+        NavigationStack {
+            iOSNetworkSettingsView(store: environment.store)
+        }
+    }
+}
+#endif

--- a/BitDream/Views/iOS/Settings/iOSSettingsView.swift
+++ b/BitDream/Views/iOS/Settings/iOSSettingsView.swift
@@ -7,11 +7,11 @@ typealias PlatformSettingsView = iOSSettingsView
 
 struct iOSSettingsView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.appUserDefaults) private var userDefaults
+    @EnvironmentObject private var appIconManager: AppIconManager
+    @EnvironmentObject private var themeManager: ThemeManager
 
     @ObservedObject var store: TransmissionStore
-
-    @ObservedObject private var themeManager = ThemeManager.shared
-    @StateObject private var appIconManager = AppIconManager.shared
     @AppStorage(UserDefaultsKeys.showContentTypeIcons) private var showContentTypeIcons: Bool = AppDefaults.showContentTypeIcons
     @AppStorage(UserDefaultsKeys.startupConnectionBehavior) private var startupBehaviorRaw: String = AppDefaults.startupConnectionBehavior.rawValue
 
@@ -81,7 +81,11 @@ struct iOSSettingsView: View {
 
                 Section(header: Text("Reset")) {
                     Button("Reset All Settings") {
-                        SettingsView.resetAllSettings(store: store)
+                        SettingsView.resetAllSettings(
+                            store: store,
+                            themeManager: themeManager,
+                            userDefaults: userDefaults
+                        )
                     }
                     .foregroundColor(.accentColor)
                 }
@@ -110,6 +114,7 @@ struct iOSSettingsView: View {
 }
 
 private struct AccentColorPicker: View {
+    @EnvironmentObject private var themeManager: ThemeManager
     @Binding var selection: AccentColorOption
 
     var body: some View {
@@ -137,7 +142,7 @@ private struct AccentColorPicker: View {
                 .onTapGesture {
                     withAnimation(.easeInOut(duration: 0.1)) {
                         selection = option
-                        ThemeManager.shared.setAccentColor(option)
+                        themeManager.setAccentColor(option)
                     }
                 }
             }
@@ -247,7 +252,11 @@ private struct CurrentAppIconPreview: View {
     }
 }
 
-#Preview {
-    iOSSettingsView(store: TransmissionStore())
+#if DEBUG
+#Preview("iOS Settings") {
+    PreviewContainer { environment in
+        iOSSettingsView(store: environment.store)
+    }
 }
+#endif
 #endif

--- a/BitDream/Views/iOS/Settings/iOSSpeedLimitsSettingsView.swift
+++ b/BitDream/Views/iOS/Settings/iOSSpeedLimitsSettingsView.swift
@@ -153,3 +153,13 @@ struct iOSSpeedLimitsSettingsView: View {
     }
 }
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Speed Limit Settings") {
+    PreviewContainer { environment in
+        NavigationStack {
+            iOSSpeedLimitsSettingsView(store: environment.store)
+        }
+    }
+}
+#endif

--- a/BitDream/Views/iOS/Settings/iOSTorrentsSettingsView.swift
+++ b/BitDream/Views/iOS/Settings/iOSTorrentsSettingsView.swift
@@ -185,3 +185,13 @@ struct iOSTorrentsSettingsView: View {
     }
 }
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Torrent Settings") {
+    PreviewContainer { environment in
+        NavigationStack {
+            iOSTorrentsSettingsView(store: environment.store)
+        }
+    }
+}
+#endif

--- a/BitDream/Views/iOS/iOSAddTorrent.swift
+++ b/BitDream/Views/iOS/iOSAddTorrent.swift
@@ -96,3 +96,11 @@ struct iOSAddTorrent: View {
     }
 }
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Add Torrent") {
+    PreviewContainer { environment in
+        iOSAddTorrent(store: environment.store)
+    }
+}
+#endif

--- a/BitDream/Views/iOS/iOSConnectionBannerView.swift
+++ b/BitDream/Views/iOS/iOSConnectionBannerView.swift
@@ -57,3 +57,12 @@ struct iOSConnectionBannerView: View {
     }
 }
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Reconnecting Banner", traits: .sizeThatFitsLayout) {
+    PreviewContainer(scenario: .reconnecting) { environment in
+        iOSConnectionBannerView(store: environment.store)
+            .frame(width: 420)
+    }
+}
+#endif

--- a/BitDream/Views/iOS/iOSContentView.swift
+++ b/BitDream/Views/iOS/iOSContentView.swift
@@ -7,17 +7,31 @@ struct iOSContentView: View {
 
     let hosts: [Host]
     @ObservedObject var store: TransmissionStore
+    private let userDefaults: UserDefaults
 
     // Store the selected torrent ID
     @State private var selectedTorrentID: Int?
 
-    @State private var sortProperty: SortProperty = UserDefaults.standard.sortProperty
-    @State private var sortOrder: SortOrder = UserDefaults.standard.sortOrder
+    @State private var sortProperty: SortProperty
+    @State private var sortOrder: SortOrder
     @State private var filterBySelection: [TorrentStatusCalc] = TorrentStatusCalc.allCases
     @State private var labelFilter = TorrentLabelFilter()
-    @AppStorage(UserDefaultsKeys.showContentTypeIcons) private var showContentTypeIcons: Bool = true
+    @AppStorage(UserDefaultsKeys.showContentTypeIcons) private var showContentTypeIcons = AppDefaults.showContentTypeIcons
     @State private var searchText: String = ""
     @State private var showPrefs: Bool = false
+
+    init(hosts: [Host], store: TransmissionStore, userDefaults: UserDefaults = .standard) {
+        self.hosts = hosts
+        self.store = store
+        self.userDefaults = userDefaults
+        _sortProperty = State(initialValue: userDefaults.sortProperty)
+        _sortOrder = State(initialValue: userDefaults.sortOrder)
+        _showContentTypeIcons = AppStorage(
+            wrappedValue: AppDefaults.showContentTypeIcons,
+            UserDefaultsKeys.showContentTypeIcons,
+            store: userDefaults
+        )
+    }
 
     var body: some View {
         Group {
@@ -108,10 +122,10 @@ private extension iOSContentView {
             bottomToolbarItems
         }
         .onChange(of: sortProperty) { _, newValue in
-            UserDefaults.standard.sortProperty = newValue
+            userDefaults.sortProperty = newValue
         }
         .onChange(of: sortOrder) { _, newValue in
-            UserDefaults.standard.sortOrder = newValue
+            userDefaults.sortOrder = newValue
         }
     }
 
@@ -307,6 +321,18 @@ private extension iOSContentView {
             uniqueKeysWithValues: store.availableLabels.map { label in
                 (label, store.torrentCount(for: label))
             }
+        )
+    }
+}
+#endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Content") {
+    PreviewContainer { environment in
+        iOSContentView(
+            hosts: environment.hosts,
+            store: environment.store,
+            userDefaults: environment.userDefaults
         )
     }
 }

--- a/BitDream/Views/iOS/iOSFilterAndSortView.swift
+++ b/BitDream/Views/iOS/iOSFilterAndSortView.swift
@@ -233,3 +233,22 @@ private enum iOSStatusFilterOption: String, CaseIterable, Identifiable {
     }
 }
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Filter and Sort") {
+    @Previewable @State var statusFilter = TorrentStatusCalc.allCases
+    @Previewable @State var labelFilter = TorrentLabelFilter()
+    @Previewable @State var sortProperty = SortProperty.name
+    @Previewable @State var sortOrder = SortOrder.ascending
+
+    iOSFilterAndSortView(
+        statusFilter: $statusFilter,
+        labelFilter: $labelFilter,
+        sortProperty: $sortProperty,
+        sortOrder: $sortOrder,
+        availableLabels: ["Archive", "ISO", "Linux", "Movies"],
+        labelCounts: ["Archive": 1, "ISO": 1, "Linux": 1, "Movies": 1],
+        noLabelCount: 1
+    )
+}
+#endif

--- a/BitDream/Views/iOS/iOSServerEditor.swift
+++ b/BitDream/Views/iOS/iOSServerEditor.swift
@@ -12,6 +12,7 @@ private enum iOSServerFormField: Hashable {
 /// Sheet for adding a new server or editing an existing one.
 struct iOSServerEditor: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.hostRepositoryProvider) private var hostRepositoryProvider
     @ObservedObject var store: TransmissionStore
     let hosts: [Host]
     let host: Host?
@@ -173,7 +174,10 @@ struct iOSServerEditor: View {
     private func save() {
         Task {
             do {
-                switch try await model.save(store: store) {
+                switch try await model.save(
+                    store: store,
+                    hostRepository: hostRepositoryProvider.resolve()
+                ) {
                 case .validationFailed(let field):
                     focusedField = focusTarget(for: field)
                 case .saved:
@@ -196,7 +200,12 @@ struct iOSServerEditor: View {
     private func performDelete(_ host: Host) {
         Task {
             do {
-                try await deleteServer(host: host, store: store, hosts: hosts)
+                try await deleteServer(
+                    host: host,
+                    store: store,
+                    hosts: hosts,
+                    hostRepository: hostRepositoryProvider.resolve()
+                )
                 dismiss()
             } catch {
                 errorMessage = userFacingHostPersistenceMessage(error)
@@ -213,6 +222,18 @@ struct iOSServerEditor: View {
         case nil:
             return nil
         }
+    }
+}
+#endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Edit Server") {
+    PreviewContainer { environment in
+        iOSServerEditor(
+            store: environment.store,
+            hosts: environment.hosts,
+            host: environment.hosts[0]
+        )
     }
 }
 #endif

--- a/BitDream/Views/iOS/iOSServerList.swift
+++ b/BitDream/Views/iOS/iOSServerList.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Sheet listing the configured servers with add, edit, connect, and delete actions.
 struct iOSServerList: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.hostRepositoryProvider) private var hostRepositoryProvider
     let hosts: [Host]
     @ObservedObject var store: TransmissionStore
 
@@ -167,13 +168,26 @@ struct iOSServerList: View {
     private func performDelete(_ host: Host) {
         Task {
             do {
-                try await deleteServer(host: host, store: store, hosts: hosts)
+                try await deleteServer(
+                    host: host,
+                    store: store,
+                    hosts: hosts,
+                    hostRepository: hostRepositoryProvider.resolve()
+                )
                 serverToDelete = nil
             } catch {
                 serverToDelete = nil
                 errorMessage = userFacingHostPersistenceMessage(error)
             }
         }
+    }
+}
+#endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Servers") {
+    PreviewContainer { environment in
+        iOSServerList(hosts: environment.hosts, store: environment.store)
     }
 }
 #endif

--- a/BitDream/Views/iOS/iOSTorrentDetail.swift
+++ b/BitDream/Views/iOS/iOSTorrentDetail.swift
@@ -504,3 +504,11 @@ private struct IOSTorrentPiecesMessageView: View {
 }
 
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Torrent Detail") {
+    PreviewContainer { environment in
+        iOSTorrentDetail(store: environment.store, torrent: PreviewFixtures.torrents[0])
+    }
+}
+#endif

--- a/BitDream/Views/iOS/iOSTorrentFileDetail.swift
+++ b/BitDream/Views/iOS/iOSTorrentFileDetail.swift
@@ -267,3 +267,16 @@ private extension iOSTorrentFileDetail {
 }
 
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Torrent Files") {
+    PreviewContainer { environment in
+        iOSTorrentFileDetail(
+            files: PreviewFixtures.files,
+            fileStats: PreviewFixtures.fileStats,
+            torrentId: PreviewFixtures.torrents[0].id,
+            store: environment.store
+        )
+    }
+}
+#endif

--- a/BitDream/Views/iOS/iOSTorrentFileDetailControls.swift
+++ b/BitDream/Views/iOS/iOSTorrentFileDetailControls.swift
@@ -252,15 +252,19 @@ struct FilterSheet: View {
     }
 }
 
+#if DEBUG
 #Preview("iOS Torrent Files") {
-    NavigationView {
-        iOSTorrentFileDetail(
-            files: TorrentFilePreviewData.sampleFiles,
-            fileStats: TorrentFilePreviewData.sampleFileStats,
-            torrentId: 1,
-            store: TransmissionStore()
-        )
+    PreviewContainer { environment in
+        NavigationStack {
+            iOSTorrentFileDetail(
+                files: PreviewFixtures.files,
+                fileStats: PreviewFixtures.fileStats,
+                torrentId: 1,
+                store: environment.store
+            )
+        }
     }
 }
+#endif
 
 #endif

--- a/BitDream/Views/iOS/iOSTorrentFileRow.swift
+++ b/BitDream/Views/iOS/iOSTorrentFileRow.swift
@@ -106,3 +106,21 @@ struct iOSTorrentFileRow: View {
 }
 
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Torrent File Row", traits: .sizeThatFitsLayout) {
+    let file = PreviewFixtures.files[0]
+    let stats = PreviewFixtures.fileStats[0]
+    let row = TorrentFileRow(
+        file: file,
+        stats: stats,
+        percentDone: file.percentDone,
+        priority: stats.priority,
+        wanted: stats.wanted,
+        displayName: file.name,
+        fileIndex: 0
+    )
+    iOSTorrentFileRow(row: row, setFileWanted: { _, _ in }, setFilePriority: { _, _ in })
+        .padding()
+}
+#endif

--- a/BitDream/Views/iOS/iOSTorrentListRow.swift
+++ b/BitDream/Views/iOS/iOSTorrentListRow.swift
@@ -600,3 +600,17 @@ struct iOSTorrentListRow: View {
     }
 }
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Torrent List Row", traits: .sizeThatFitsLayout) {
+    PreviewContainer { environment in
+        iOSTorrentListRow(
+            torrent: PreviewFixtures.torrents[0],
+            store: environment.store,
+            showContentTypeIcons: true,
+            destinationID: nil
+        )
+        .padding()
+    }
+}
+#endif

--- a/BitDream/Views/iOS/iOSTorrentPeerDetail.swift
+++ b/BitDream/Views/iOS/iOSTorrentPeerDetail.swift
@@ -168,3 +168,19 @@ struct iOSTorrentPeerDetail: View {
     var body: some View { EmptyView() }
 }
 #endif
+
+#if os(iOS) && DEBUG
+#Preview("iOS Torrent Peers") {
+    PreviewContainer { environment in
+        iOSTorrentPeerDetail(
+            torrentName: PreviewFixtures.torrents[0].name,
+            torrentId: PreviewFixtures.torrents[0].id,
+            store: environment.store,
+            peers: PreviewFixtures.peers,
+            peersFrom: PreviewFixtures.peersFrom,
+            onRefresh: {},
+            onDone: {}
+        )
+    }
+}
+#endif

--- a/BitDream/Views/macOS/DockSpeedTileView.swift
+++ b/BitDream/Views/macOS/DockSpeedTileView.swift
@@ -113,3 +113,11 @@ private struct DockSpeedBadge: View {
     }
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("Dock Speed Tile", traits: .fixedLayout(width: 128, height: 128)) {
+    DockSpeedTileView(
+        content: DockSpeedTileContent(downloadSpeed: 18_400_000, uploadSpeed: 5_620_000)
+    )
+}
+#endif

--- a/BitDream/Views/macOS/MenuBar/macOSMenuBarTorrentRow.swift
+++ b/BitDream/Views/macOS/MenuBar/macOSMenuBarTorrentRow.swift
@@ -90,3 +90,9 @@ struct macOSMenuBarTorrentRow: View {
 }
 
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("Menu Bar Torrent Row", traits: .fixedLayout(width: 360, height: 90)) {
+    macOSMenuBarTorrentRow(torrent: PreviewFixtures.torrents[0], onOpen: {})
+}
+#endif

--- a/BitDream/Views/macOS/MenuBar/macOSMenuBarTorrentWidget.swift
+++ b/BitDream/Views/macOS/MenuBar/macOSMenuBarTorrentWidget.swift
@@ -242,3 +242,11 @@ private struct TorrentRowsHeightPreferenceKey: PreferenceKey {
 }
 
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("Menu Bar Torrent Widget") {
+    PreviewContainer { _ in
+        macOSMenuBarTorrentWidget()
+    }
+}
+#endif

--- a/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
+++ b/BitDream/Views/macOS/Settings/macOSGeneralSettingsTab.swift
@@ -3,10 +3,11 @@ import Foundation
 
 #if os(macOS)
 struct macOSGeneralSettingsTab: View {
+    @Environment(\.appUserDefaults) private var userDefaults
     @EnvironmentObject private var appUpdater: AppUpdater
+    @EnvironmentObject private var themeManager: ThemeManager
     @ObservedObject var store: TransmissionStore
 
-    @ObservedObject private var themeManager = ThemeManager.shared
     @AppStorage(UserDefaultsKeys.showContentTypeIcons) private var showContentTypeIcons: Bool = AppDefaults.showContentTypeIcons
     @AppStorage(UserDefaultsKeys.menuBarTransferWidgetEnabled) private var menuBarTransferWidgetEnabled: Bool = AppDefaults.menuBarTransferWidgetEnabled
     @AppStorage(UserDefaultsKeys.menuBarShowActiveCount) private var menuBarShowActiveCount: Bool = AppDefaults.menuBarShowActiveCount
@@ -187,7 +188,11 @@ struct macOSGeneralSettingsTab: View {
 
                     settingsSection("Reset") {
                         Button("Reset All Settings") {
-                            SettingsView.resetAllSettings(store: store) {
+                            SettingsView.resetAllSettings(
+                                store: store,
+                                themeManager: themeManager,
+                                userDefaults: userDefaults
+                            ) {
                                 appUpdater.resetToDefaults()
                             }
                         }
@@ -215,6 +220,14 @@ struct macOSGeneralSettingsTab: View {
     private var divider: some View {
         Divider()
             .padding(.vertical, 4)
+    }
+}
+#endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS General Settings", traits: .fixedLayout(width: 760, height: 700)) {
+    PreviewContainer { environment in
+        macOSGeneralSettingsTab(store: environment.store)
     }
 }
 #endif

--- a/BitDream/Views/macOS/Settings/macOSNetworkSettingsTab.swift
+++ b/BitDream/Views/macOS/Settings/macOSNetworkSettingsTab.swift
@@ -13,3 +13,11 @@ struct macOSNetworkSettingsTab: View {
     }
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Network Settings", traits: .fixedLayout(width: 760, height: 700)) {
+    @Previewable @StateObject var editModel = SettingsViewModel()
+    macOSNetworkSettingsTab(config: PreviewFixtures.sessionConfiguration, editModel: editModel)
+        .padding()
+}
+#endif

--- a/BitDream/Views/macOS/Settings/macOSSettingsView.swift
+++ b/BitDream/Views/macOS/Settings/macOSSettingsView.swift
@@ -5,10 +5,9 @@ import Foundation
 typealias PlatformSettingsView = macOSSettingsView
 
 struct macOSSettingsView: View {
+    @EnvironmentObject private var themeManager: ThemeManager
     @ObservedObject var store: TransmissionStore
     @StateObject private var editModel = SettingsViewModel()
-
-    @ObservedObject private var themeManager = ThemeManager.shared
 
     var body: some View {
         TabView {
@@ -89,8 +88,11 @@ private struct SettingsServerTab<Content: View>: View {
     }
 }
 
-#Preview {
-    macOSSettingsView(store: TransmissionStore())
-        .environmentObject(AppUpdater())
+#if DEBUG
+#Preview("macOS Settings") {
+    PreviewContainer { environment in
+        macOSSettingsView(store: environment.store)
+    }
 }
+#endif
 #endif

--- a/BitDream/Views/macOS/Settings/macOSSpeedLimitsSettingsTab.swift
+++ b/BitDream/Views/macOS/Settings/macOSSpeedLimitsSettingsTab.swift
@@ -13,3 +13,11 @@ struct macOSSpeedLimitsSettingsTab: View {
     }
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Speed Limit Settings", traits: .fixedLayout(width: 760, height: 620)) {
+    @Previewable @StateObject var editModel = SettingsViewModel()
+    macOSSpeedLimitsSettingsTab(config: PreviewFixtures.sessionConfiguration, editModel: editModel)
+        .padding()
+}
+#endif

--- a/BitDream/Views/macOS/Settings/macOSTorrentSettingsTab.swift
+++ b/BitDream/Views/macOS/Settings/macOSTorrentSettingsTab.swift
@@ -45,3 +45,11 @@ struct macOSTorrentSettingsTab: View {
     }
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Torrent Settings", traits: .fixedLayout(width: 760, height: 760)) {
+    @Previewable @StateObject var editModel = SettingsViewModel()
+    macOSTorrentSettingsTab(config: PreviewFixtures.sessionConfiguration, editModel: editModel)
+        .padding()
+}
+#endif

--- a/BitDream/Views/macOS/macOSAboutView.swift
+++ b/BitDream/Views/macOS/macOSAboutView.swift
@@ -93,3 +93,11 @@ struct macOSAboutView: View {
 }
 
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS About", traits: .fixedLayout(width: 420, height: 480)) {
+    PreviewContainer { _ in
+        macOSAboutView()
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSAddTorrent.swift
+++ b/BitDream/Views/macOS/macOSAddTorrent.swift
@@ -443,7 +443,11 @@ private struct TorrentSourceCard: View {
 }
 
 // MARK: - Preview
+#if DEBUG
 #Preview("Add Torrent") {
-    macOSAddTorrent(store: TransmissionStore())
+    PreviewContainer { environment in
+        macOSAddTorrent(store: environment.store)
+    }
 }
+#endif
 #endif

--- a/BitDream/Views/macOS/macOSConnectionBannerView.swift
+++ b/BitDream/Views/macOS/macOSConnectionBannerView.swift
@@ -43,3 +43,11 @@ struct macOSConnectionBannerView: View {
     }
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Reconnecting Banner", traits: .fixedLayout(width: 720, height: 70)) {
+    PreviewContainer(scenario: .reconnecting) { environment in
+        macOSConnectionBannerView(store: environment.store)
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSConnectionInfoView.swift
+++ b/BitDream/Views/macOS/macOSConnectionInfoView.swift
@@ -92,3 +92,11 @@ struct macOSConnectionInfoView: View {
     }
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Connection Info") {
+    PreviewContainer(scenario: .reconnecting) { _ in
+        macOSConnectionInfoView()
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSContentDetail.swift
+++ b/BitDream/Views/macOS/macOSContentDetail.swift
@@ -330,3 +330,38 @@ struct TorrentDropDelegate: DropDelegate {
 }
 
 #endif
+
+#if os(macOS) && DEBUG
+private struct macOSContentDetailPreviewHost: View {
+    let store: TransmissionStore
+    @State private var selectedTorrentIDs = Set<Int>()
+    @State private var sortProperty = SortProperty.name
+    @State private var sortOrder = SortOrder.ascending
+    @State private var isDropTargeted = false
+    @State private var draggedTorrentInfo: [TorrentInfo] = []
+    @FocusState private var focusedTarget: macOSContentView.FocusTarget?
+
+    var body: some View {
+        macOSContentDetail(
+            store: store,
+            torrents: PreviewFixtures.torrents,
+            isCompactMode: false,
+            selectedTorrentIds: $selectedTorrentIDs,
+            sortProperty: $sortProperty,
+            sortOrder: $sortOrder,
+            selectedTorrents: [],
+            showContentTypeIcons: true,
+            accentColor: .blue,
+            isDropTargeted: $isDropTargeted,
+            draggedTorrentInfo: $draggedTorrentInfo,
+            focusedTarget: $focusedTarget
+        )
+    }
+}
+
+#Preview("macOS Content Detail", traits: .fixedLayout(width: 1_000, height: 620)) {
+    PreviewContainer { environment in
+        macOSContentDetailPreviewHost(store: environment.store)
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSContentSidebar.swift
+++ b/BitDream/Views/macOS/macOSContentSidebar.swift
@@ -64,3 +64,21 @@ struct macOSContentSidebar: View {
 }
 
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Sidebar", traits: .fixedLayout(width: 300, height: 620)) {
+    @Previewable @State var selection = SidebarSelection.allDreams
+    let hosts = PreviewFixtures.makeHosts()
+    macOSContentSidebar(
+        hosts: hosts,
+        sidebarSelection: $selection,
+        selectedHostID: hosts[0].serverID,
+        accentColor: .blue,
+        torrentCount: { _ in 5 },
+        onSelectHost: { _ in },
+        onAddServer: {},
+        onManageServers: {},
+        onOpenSettings: {}
+    )
+}
+#endif

--- a/BitDream/Views/macOS/macOSContentToolbar.swift
+++ b/BitDream/Views/macOS/macOSContentToolbar.swift
@@ -243,3 +243,39 @@ private struct macOSContentFilterMenu: View {
 }
 
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Content Toolbar", traits: .fixedLayout(width: 900, height: 180)) {
+    @Previewable @State var sortProperty = SortProperty.name
+    @Previewable @State var sortOrder = SortOrder.ascending
+    @Previewable @State var showingFilterPopover = false
+    @Previewable @State var includedLabels = Set<String>()
+    @Previewable @State var excludedLabels = Set<String>()
+    @Previewable @State var showOnlyNoLabels = false
+    @Previewable @State var isCompactMode = false
+    @Previewable @State var isInspectorVisible = true
+
+    NavigationStack {
+        Text("Torrent List")
+            .toolbar {
+                macOSContentToolbar(
+                    sortProperty: $sortProperty,
+                    sortOrder: $sortOrder,
+                    showingFilterPopover: $showingFilterPopover,
+                    hasActiveFilters: false,
+                    activeFilterCount: 0,
+                    accentColor: .blue,
+                    availableLabels: ["Linux", "Movies"],
+                    includedLabels: $includedLabels,
+                    excludedLabels: $excludedLabels,
+                    showOnlyNoLabels: $showOnlyNoLabels,
+                    noLabelCount: 1,
+                    countForLabel: { _ in 1 },
+                    isCompactMode: $isCompactMode,
+                    isInspectorVisible: $isInspectorVisible,
+                    onAddTorrent: {}
+                )
+            }
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSContentView.swift
+++ b/BitDream/Views/macOS/macOSContentView.swift
@@ -8,23 +8,23 @@ import Foundation
 struct macOSContentView: View {
     @Environment(\.openSettings) private var openSettings
     @Environment(\.openWindow) private var openWindow
+    @EnvironmentObject private var themeManager: ThemeManager
     let hosts: [Host]
     @ObservedObject var store: TransmissionStore
+    private let userDefaults: UserDefaults
 
-    @ObservedObject private var themeManager = ThemeManager.shared
-
-    @State var sortProperty: SortProperty = UserDefaults.standard.sortProperty
-    @State var sortOrder: SortOrder = UserDefaults.standard.sortOrder
+    @State var sortProperty: SortProperty
+    @State var sortOrder: SortOrder
     @State private var filterBySelection: [TorrentStatusCalc] = TorrentStatusCalc.allCases
     @State private var sidebarSelection: SidebarSelection = .allDreams
-    @State private var isInspectorVisible: Bool = UserDefaults.standard.inspectorVisibility
-    @State private var columnVisibility: NavigationSplitViewVisibility = UserDefaults.standard.sidebarVisibility
+    @State private var isInspectorVisible: Bool
+    @State private var columnVisibility: NavigationSplitViewVisibility
     @State private var searchText: String = ""
     @State private var includedLabels: Set<String> = []
     @State private var excludedLabels: Set<String> = []
     @State private var showOnlyNoLabels: Bool = false
-    @AppStorage(UserDefaultsKeys.torrentListCompactMode) private var isCompactMode: Bool = false
-    @AppStorage(UserDefaultsKeys.showContentTypeIcons) private var showContentTypeIcons: Bool = true
+    @AppStorage(UserDefaultsKeys.torrentListCompactMode) private var isCompactMode = false
+    @AppStorage(UserDefaultsKeys.showContentTypeIcons) private var showContentTypeIcons = AppDefaults.showContentTypeIcons
 
     // Selection state - kept local to avoid "Publishing changes from within view updates" warning
     // Exposed to menu commands via @FocusedValue
@@ -40,6 +40,26 @@ struct macOSContentView: View {
     @State private var isDropTargeted = false
     @State private var draggedTorrentInfo: [TorrentInfo] = []
     @State private var showingFilterPopover = false
+
+    init(hosts: [Host], store: TransmissionStore, userDefaults: UserDefaults = .standard) {
+        self.hosts = hosts
+        self.store = store
+        self.userDefaults = userDefaults
+        _sortProperty = State(initialValue: userDefaults.sortProperty)
+        _sortOrder = State(initialValue: userDefaults.sortOrder)
+        _isInspectorVisible = State(initialValue: userDefaults.inspectorVisibility)
+        _columnVisibility = State(initialValue: userDefaults.sidebarVisibility)
+        _isCompactMode = AppStorage(
+            wrappedValue: false,
+            UserDefaultsKeys.torrentListCompactMode,
+            store: userDefaults
+        )
+        _showContentTypeIcons = AppStorage(
+            wrappedValue: AppDefaults.showContentTypeIcons,
+            UserDefaultsKeys.showContentTypeIcons,
+            store: userDefaults
+        )
+    }
 
     // Base view with basic modifiers
     private var baseView: some View {
@@ -93,11 +113,11 @@ struct macOSContentView: View {
     private var enhancedView: some View {
         viewWithHandlers
         .onChange(of: columnVisibility) { _, newValue in
-            UserDefaults.standard.sidebarVisibility = newValue
+            userDefaults.sidebarVisibility = newValue
             focusedTarget = .contentList
         }
         .onChange(of: isInspectorVisible) { _, newValue in
-            UserDefaults.standard.inspectorVisibility = newValue
+            userDefaults.inspectorVisibility = newValue
             // Defer state change to avoid publishing during view update
             Task { @MainActor in
                 store.isInspectorVisible = newValue
@@ -105,10 +125,10 @@ struct macOSContentView: View {
             focusedTarget = .contentList
         }
         .onChange(of: sortProperty) { _, newValue in
-            UserDefaults.standard.sortProperty = newValue
+            userDefaults.sortProperty = newValue
         }
         .onChange(of: sortOrder) { _, newValue in
-            UserDefaults.standard.sortOrder = newValue
+            userDefaults.sortOrder = newValue
         }
         .onChange(of: store.shouldActivateSearch) { _, newValue in
             if newValue {
@@ -349,12 +369,12 @@ enum LabelFilterAction {
 }
 
 struct LabelFilterChip: View {
+    @EnvironmentObject private var themeManager: ThemeManager
     let label: String
     let count: Int
     let isIncluded: Bool
     let isExcluded: Bool
     let onAction: (LabelFilterAction) -> Void
-    @ObservedObject private var themeManager = ThemeManager.shared
 
     private var backgroundColor: Color {
         if isIncluded {
@@ -426,6 +446,18 @@ struct LabelFilterChip: View {
             .clipShape(RoundedRectangle(cornerRadius: 12))
         .buttonStyle(.plain)
         .help(isIncluded ? "Click to exclude '\(label)'" : isExcluded ? "Click to clear filter" : "Click to include '\(label)'")
+    }
+}
+#endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Content", traits: .fixedLayout(width: 1_200, height: 760)) {
+    PreviewContainer { environment in
+        macOSContentView(
+            hosts: environment.hosts,
+            store: environment.store,
+            userDefaults: environment.userDefaults
+        )
     }
 }
 #endif

--- a/BitDream/Views/macOS/macOSServerDetail.swift
+++ b/BitDream/Views/macOS/macOSServerDetail.swift
@@ -3,6 +3,7 @@ import SwiftUI
 #if os(macOS)
 struct macOSServerDetail: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.hostRepositoryProvider) private var hostRepositoryProvider
 
     @ObservedObject var store: TransmissionStore
     let hosts: [Host]
@@ -34,7 +35,12 @@ struct macOSServerDetail: View {
                 if let host {
                     Task {
                         do {
-                            try await deleteServer(host: host, store: store, hosts: hosts)
+                            try await deleteServer(
+                                host: host,
+                                store: store,
+                                hosts: hosts,
+                                hostRepository: hostRepositoryProvider.resolve()
+                            )
                             dismiss()
                         } catch {
                             presentError(userFacingHostPersistenceMessage(error))
@@ -52,6 +58,18 @@ struct macOSServerDetail: View {
         store.globalAlertTitle = "Error"
         store.globalAlertMessage = message
         store.showGlobalAlert = true
+    }
+}
+#endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Server Detail") {
+    PreviewContainer { environment in
+        macOSServerDetail(
+            store: environment.store,
+            hosts: environment.hosts,
+            host: environment.hosts[0]
+        )
     }
 }
 #endif

--- a/BitDream/Views/macOS/macOSServerEditor.swift
+++ b/BitDream/Views/macOS/macOSServerEditor.swift
@@ -10,6 +10,7 @@ private enum macOSServerFormFocusField: Hashable {
 }
 
 struct macOSServerEditor: View {
+    @Environment(\.hostRepositoryProvider) private var hostRepositoryProvider
     @ObservedObject var store: TransmissionStore
     let hosts: [Host]
     let host: Host?
@@ -155,7 +156,10 @@ struct macOSServerEditor: View {
     private func performSave() {
         Task {
             do {
-                switch try await model.save(store: store) {
+                switch try await model.save(
+                    store: store,
+                    hostRepository: hostRepositoryProvider.resolve()
+                ) {
                 case .validationFailed(let field):
                     focusedField = focusTarget(for: field)
                 case .saved(let savedHost):
@@ -176,6 +180,30 @@ struct macOSServerEditor: View {
         case nil:
             return nil
         }
+    }
+}
+#endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Server Editor", traits: .fixedLayout(width: 460, height: 560)) {
+    @Previewable @State var hasUnsavedChanges = false
+    @Previewable @State var isSaving = false
+
+    PreviewContainer { environment in
+        macOSServerEditor(
+            store: environment.store,
+            hosts: environment.hosts,
+            host: environment.hosts[0],
+            title: "Edit Server",
+            saveButtonTitle: "Save",
+            cancelButtonTitle: "Cancel",
+            onCancel: {},
+            onSaved: { _ in },
+            onDelete: {},
+            hasUnsavedChanges: $hasUnsavedChanges,
+            isSaving: $isSaving,
+            onError: { _ in }
+        )
     }
 }
 #endif

--- a/BitDream/Views/macOS/macOSServerList.swift
+++ b/BitDream/Views/macOS/macOSServerList.swift
@@ -164,6 +164,7 @@ struct macOSManageServersWindow: View {
 }
 
 struct macOSServerList: View {
+    @Environment(\.hostRepositoryProvider) private var hostRepositoryProvider
     let hosts: [Host]
     @ObservedObject var store: TransmissionStore
 
@@ -499,7 +500,12 @@ private extension macOSServerList {
     private func performDelete(_ host: Host) {
         Task {
             do {
-                try await deleteServer(host: host, store: store, hosts: hosts)
+                try await deleteServer(
+                    host: host,
+                    store: store,
+                    hosts: hosts,
+                    hostRepository: hostRepositoryProvider.resolve()
+                )
                 let remainingServerIDs = sortedHosts
                     .filter { $0.serverID != host.serverID }
                     .map(\.serverID)
@@ -521,4 +527,12 @@ private extension macOSServerList {
     }
 }
 
+#endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Server List", traits: .fixedLayout(width: 900, height: 600)) {
+    PreviewContainer { environment in
+        macOSServerList(hosts: environment.hosts, store: environment.store)
+    }
+}
 #endif

--- a/BitDream/Views/macOS/macOSStatisticsView.swift
+++ b/BitDream/Views/macOS/macOSStatisticsView.swift
@@ -122,3 +122,11 @@ struct macOSStatisticsView: View {
 
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Statistics") {
+    PreviewContainer { _ in
+        macOSStatisticsView()
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSTorrentActionsMenu.swift
+++ b/BitDream/Views/macOS/macOSTorrentActionsMenu.swift
@@ -518,3 +518,26 @@ private func deleteTorrents(
 }
 
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Rename Torrent", traits: .fixedLayout(width: 480, height: 220)) {
+    @Previewable @State var renameInput = PreviewFixtures.torrents[0].name
+    @Previewable @State var renameTargetID: Int? = PreviewFixtures.torrents[0].id
+    @Previewable @State var isPresented = true
+    @Previewable @State var showingError = false
+    @Previewable @State var errorMessage = ""
+
+    PreviewContainer { environment in
+        RenameSheetContent(
+            store: environment.store,
+            selectedTorrents: [PreviewFixtures.torrents[0]],
+            renameInput: $renameInput,
+            renameTargetId: $renameTargetID,
+            isPresented: $isPresented,
+            showingError: $showingError,
+            errorMessage: $errorMessage
+        )
+        .padding()
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSTorrentDetail.swift
+++ b/BitDream/Views/macOS/macOSTorrentDetail.swift
@@ -470,3 +470,11 @@ struct macOSSectionHeader: View {
     }
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Torrent Detail", traits: .fixedLayout(width: 900, height: 720)) {
+    PreviewContainer { environment in
+        macOSTorrentDetail(store: environment.store, torrent: PreviewFixtures.torrents[0])
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSTorrentEdit.swift
+++ b/BitDream/Views/macOS/macOSTorrentEdit.swift
@@ -299,3 +299,17 @@ internal func bulkLabelUpdates(
 }
 
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Torrent Edit", traits: .fixedLayout(width: 480, height: 260)) {
+    @Previewable @State var name = "Ubuntu 26.04 Desktop"
+    RenameSheetView(
+        title: "Rename Torrent",
+        name: $name,
+        currentName: "Ubuntu 26.04",
+        onCancel: {},
+        onSave: { _ in }
+    )
+    .padding()
+}
+#endif

--- a/BitDream/Views/macOS/macOSTorrentFileDetail.swift
+++ b/BitDream/Views/macOS/macOSTorrentFileDetail.swift
@@ -430,14 +430,18 @@ struct FooterView: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview("macOS Torrent Files") {
-    macOSTorrentFileDetail(
-        files: TorrentFilePreviewData.sampleFiles,
-        fileStats: TorrentFilePreviewData.sampleFileStats,
-        torrentId: 1,
-        store: TransmissionStore()
-    )
-    .frame(width: 1000, height: 700)
+    PreviewContainer { environment in
+        macOSTorrentFileDetail(
+            files: PreviewFixtures.files,
+            fileStats: PreviewFixtures.fileStats,
+            torrentId: 1,
+            store: environment.store
+        )
+        .frame(width: 1000, height: 700)
+    }
 }
+#endif
 
 #endif

--- a/BitDream/Views/macOS/macOSTorrentList.swift
+++ b/BitDream/Views/macOS/macOSTorrentList.swift
@@ -140,3 +140,16 @@ struct TorrentRowModifier: ViewModifier {
 }
 
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Interactive Torrent Row", traits: .fixedLayout(width: 700, height: 110)) {
+    PreviewContainer { environment in
+        macOSTorrentListExpanded(
+            torrent: PreviewFixtures.torrents[0],
+            store: environment.store,
+            selectedTorrents: [PreviewFixtures.torrents[0]],
+            showContentTypeIcons: true
+        )
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSTorrentListCompact.swift
+++ b/BitDream/Views/macOS/macOSTorrentListCompact.swift
@@ -464,3 +464,22 @@ private extension macOSTorrentListCompact {
     }
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Compact Torrent List", traits: .fixedLayout(width: 1_000, height: 420)) {
+    @Previewable @State var selection = Set<Int>()
+    @Previewable @State var sortProperty = SortProperty.name
+    @Previewable @State var sortOrder = SortOrder.ascending
+
+    PreviewContainer { environment in
+        macOSTorrentListCompact(
+            torrents: PreviewFixtures.torrents,
+            selection: $selection,
+            sortProperty: $sortProperty,
+            sortOrder: $sortOrder,
+            store: environment.store,
+            showContentTypeIcons: true
+        )
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSTorrentListExpanded.swift
+++ b/BitDream/Views/macOS/macOSTorrentListExpanded.swift
@@ -76,3 +76,16 @@ struct macOSTorrentListExpanded: View {
     }
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Expanded Torrent Row", traits: .fixedLayout(width: 700, height: 110)) {
+    PreviewContainer { environment in
+        macOSTorrentListExpanded(
+            torrent: PreviewFixtures.torrents[0],
+            store: environment.store,
+            selectedTorrents: [PreviewFixtures.torrents[0]],
+            showContentTypeIcons: true
+        )
+    }
+}
+#endif

--- a/BitDream/Views/macOS/macOSTorrentPeerDetail.swift
+++ b/BitDream/Views/macOS/macOSTorrentPeerDetail.swift
@@ -111,3 +111,19 @@ struct macOSTorrentPeerDetail: View {
     var body: some View { EmptyView() }
 }
 #endif
+
+#if os(macOS) && DEBUG
+#Preview("macOS Torrent Peers", traits: .fixedLayout(width: 1_000, height: 620)) {
+    PreviewContainer { environment in
+        macOSTorrentPeerDetail(
+            torrentName: PreviewFixtures.torrents[0].name,
+            torrentId: PreviewFixtures.torrents[0].id,
+            store: environment.store,
+            peers: PreviewFixtures.peers,
+            peersFrom: PreviewFixtures.peersFrom,
+            onRefresh: {},
+            onDone: {}
+        )
+    }
+}
+#endif

--- a/BitDreamTests/Views/PreviewCoverageTests.swift
+++ b/BitDreamTests/Views/PreviewCoverageTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import XCTest
+
+#if DEBUG
+final class PreviewCoverageTests: XCTestCase {
+    func testEverySwiftUIViewFileHasAColocatedPreview() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceRoots = [
+            repositoryRoot.appending(path: "BitDream"),
+            repositoryRoot.appending(path: "BitDreamWidgets")
+        ]
+        let viewPattern = try NSRegularExpression(
+            pattern: #"(?m)^\s*(?:(?:private|internal|public)\s+)?struct\s+\w+(?:<[^>]+>)?\s*:\s*View\b"#
+        )
+        var missingPreviews: [String] = []
+
+        for sourceRoot in sourceRoots {
+            guard let enumerator = FileManager.default.enumerator(
+                at: sourceRoot,
+                includingPropertiesForKeys: [.isRegularFileKey]
+            ) else {
+                XCTFail("Unable to enumerate \(sourceRoot.path)")
+                continue
+            }
+
+            for case let fileURL as URL in enumerator where fileURL.pathExtension == "swift" {
+                guard !fileURL.path.contains("/PreviewSupport/") else { continue }
+                let source = try String(contentsOf: fileURL, encoding: .utf8)
+                let sourceRange = NSRange(source.startIndex..., in: source)
+                guard viewPattern.firstMatch(in: source, range: sourceRange) != nil else { continue }
+                guard !source.contains("#Preview"), !source.contains("PreviewProvider") else { continue }
+
+                missingPreviews.append(
+                    fileURL.path.replacingOccurrences(of: repositoryRoot.path + "/", with: "")
+                )
+            }
+        }
+
+        XCTAssertTrue(
+            missingPreviews.isEmpty,
+            "SwiftUI view files without a colocated preview:\n\(missingPreviews.sorted().joined(separator: "\n"))"
+        )
+    }
+}
+#endif

--- a/BitDreamTests/Views/PreviewFixturesTests.swift
+++ b/BitDreamTests/Views/PreviewFixturesTests.swift
@@ -1,0 +1,119 @@
+import SwiftData
+import XCTest
+@testable import BitDream
+
+#if DEBUG
+@MainActor
+final class PreviewFixturesTests: XCTestCase {
+    func testConnectedScenarioIsDeterministicAndInternallyConsistent() {
+        let hosts = PreviewFixtures.makeHosts()
+        let store = PreviewFixtures.makeStore(scenario: .connected, selectedHost: hosts[0])
+
+        XCTAssertEqual(store.host?.serverID, "preview-home")
+        XCTAssertEqual(store.connectionStatus, .connected)
+        XCTAssertEqual(store.torrents, PreviewFixtures.torrents)
+        XCTAssertEqual(store.sessionStats?.torrentCount, PreviewFixtures.torrents.count)
+        XCTAssertEqual(Set(store.torrents.map(\.id)).count, store.torrents.count)
+        XCTAssertEqual(store.availableLabels, store.availableLabels.sorted())
+    }
+
+    func testFileFixturesStayAligned() {
+        XCTAssertFalse(PreviewFixtures.files.isEmpty)
+        XCTAssertEqual(PreviewFixtures.files.count, PreviewFixtures.fileStats.count)
+
+        for (file, stats) in zip(PreviewFixtures.files, PreviewFixtures.fileStats) {
+            XCTAssertEqual(file.bytesCompleted, stats.bytesCompleted)
+            XCTAssertLessThanOrEqual(file.bytesCompleted, file.length)
+        }
+    }
+
+    func testPreviewContainerUsesEphemeralSeededPersistence() throws {
+        let hosts = PreviewFixtures.makeHosts()
+        let container = PreviewFixtures.makeModelContainer(hosts: hosts)
+        let fetchedHosts = try container.mainContext.fetch(FetchDescriptor<BitDream.Host>())
+
+        XCTAssertEqual(Set(fetchedHosts.map(\.serverID)), Set(hosts.map(\.serverID)))
+        XCTAssertTrue(container.configurations.allSatisfy { $0.isStoredInMemoryOnly })
+    }
+
+    func testPreviewStoreDoesNotScheduleAutomaticRetries() {
+        let store = PreviewFixtures.makeStore(scenario: .connected)
+
+        store.handleConnectionError(.timeout)
+
+        XCTAssertEqual(store.connectionStatus, .reconnecting)
+        XCTAssertNil(store.nextRetryAt)
+    }
+
+    func testPreviewHostRepositoryPersistsOnlyInMemoryWithoutCredentials() async throws {
+        let environment = PreviewEnvironment()
+        let host = try await environment.hostRepository.create(
+            draft: HostDraft(
+                name: "Preview Lab",
+                server: "preview.invalid",
+                port: 9091,
+                username: "preview",
+                isSSL: true,
+                isDefault: false,
+                password: "must-not-reach-keychain"
+            )
+        )
+        let fetchedHosts = try environment.container.mainContext.fetch(FetchDescriptor<BitDream.Host>())
+
+        XCTAssertTrue(fetchedHosts.contains { $0.serverID == host.serverID })
+        XCTAssertNil(host.credentialKey)
+    }
+
+    func testPreviewDependenciesPersistOnlyToTheirInjectedPreferences() throws {
+        let firstSuiteName = "BitDreamTests.preview.first.\(UUID().uuidString)"
+        let secondSuiteName = "BitDreamTests.preview.second.\(UUID().uuidString)"
+        let firstDefaults = try XCTUnwrap(UserDefaults(suiteName: firstSuiteName))
+        let secondDefaults = try XCTUnwrap(UserDefaults(suiteName: secondSuiteName))
+        defer {
+            firstDefaults.removePersistentDomain(forName: firstSuiteName)
+            secondDefaults.removePersistentDomain(forName: secondSuiteName)
+        }
+        let secondPollIntervalBefore = secondDefaults.object(forKey: UserDefaultsKeys.pollInterval) as? Double
+        let secondThemeModeBefore = secondDefaults.string(forKey: "themeModeKey")
+
+        let store = PreviewFixtures.makeStore(userDefaults: firstDefaults)
+        let themeManager = ThemeManager(userDefaults: firstDefaults)
+        store.updatePollInterval(30)
+        themeManager.setThemeMode(.dark)
+
+        XCTAssertEqual(firstDefaults.double(forKey: UserDefaultsKeys.pollInterval), 30)
+        XCTAssertEqual(firstDefaults.string(forKey: "themeModeKey"), ThemeMode.dark.rawValue)
+        XCTAssertEqual(
+            secondDefaults.object(forKey: UserDefaultsKeys.pollInterval) as? Double,
+            secondPollIntervalBefore
+        )
+        XCTAssertEqual(secondDefaults.string(forKey: "themeModeKey"), secondThemeModeBefore)
+    }
+
+    #if os(macOS)
+    func testDisabledUpdaterIsInert() {
+        let updater = AppUpdater(updatesEnabled: false)
+
+        XCTAssertFalse(updater.canCheckForUpdates)
+        XCTAssertNil(updater.lastUpdateCheckDate)
+        updater.automaticallyChecksForUpdates = false
+        updater.checkForUpdates()
+
+        XCTAssertFalse(updater.automaticallyChecksForUpdates)
+        XCTAssertFalse(updater.canCheckForUpdates)
+    }
+    #endif
+
+    #if os(iOS)
+    func testInertAppIconManagerUpdatesOnlyItsLocalState() async {
+        let manager = AppIconManager.inert()
+
+        manager.selectIcon(name: "Blue")
+        await Task.yield()
+
+        XCTAssertEqual(manager.currentIconName, "Blue")
+        XCTAssertNil(manager.lastError)
+    }
+    #endif
+}
+#endif

--- a/BitDreamWidgets/SessionOverviewWidget.swift
+++ b/BitDreamWidgets/SessionOverviewWidget.swift
@@ -208,3 +208,16 @@ private struct SessionOverviewBackground: View {
         }
     }
 }
+
+#if DEBUG
+#Preview("Widget Background", traits: .fixedLayout(width: 360, height: 169)) {
+    SessionOverviewBackground(
+        entry: SessionOverviewEntry(
+            date: .now,
+            snapshot: nil,
+            isStale: false,
+            isPlaceholder: true
+        )
+    )
+}
+#endif


### PR DESCRIPTION
## Summary

- add a shared, debug-only preview environment with deterministic empty, connected, reconnecting, and error scenarios
- provide representative fixtures for servers, torrents, session statistics, files, peers, and session configuration
- add useful colocated previews throughout the iOS, macOS, shared SwiftUI, and widget view sources
- isolate interactive previews from production persistence, credentials, networking, preferences, updates, app icons, background scheduling, widget writes, and retry behavior
- add regression tests for fixture integrity, dependency isolation, and source-file preview coverage

## Why

Issue #30 called for global test data and reliable SwiftUI previews. The view layer previously had no consistent preview composition root: many views require environment objects, SwiftData models, stored preferences, or live application services. Previewing those views individually was either incomplete, failed because dependencies were missing, or risked invoking production behavior from an interactive canvas.

This change establishes one explicit preview boundary. Views continue to use their normal production dependencies by default, while previews receive deterministic in-memory data and inert service implementations. This keeps previews representative without introducing preview-only behavior into production code paths.

## Implementation

### Shared preview composition

`PreviewContainer` owns a stable `PreviewEnvironment` for the lifetime of the canvas. It supplies:

- an in-memory SwiftData model container
- isolated `UserDefaults` suites and `defaultAppStorage`
- a deterministic `TransmissionStore`
- an isolated `ThemeManager`
- an inert `AppUpdater` on macOS
- an inert `AppIconManager` on iOS
- an in-memory host repository for interactive server create, edit, and delete flows

`PreviewFixtures` centralizes representative model data so individual previews remain small and colocated with their views.

### Side-effect isolation

The production implementations remain the defaults. Preview composition explicitly replaces boundaries that could otherwise mutate user or system state:

- connection resolution never performs network traffic
- automatic connection retries are disabled
- widget snapshot writes and timeline reloads are no-ops
- background activity interval updates are no-ops
- version persistence uses an injected no-op closure
- host mutations remain inside the in-memory SwiftData container and never reach Keychain or the production host catalog
- preferences use a unique preview-only suite while retaining live `@AppStorage` observation
- Sparkle and alternate-icon operations are disabled while preserving local UI state for interaction

### Preview coverage

Every source file that defines a SwiftUI `View` now has a useful colocated preview. A coverage test scans the app and widget source trees and fails when a future view file is added without a preview. Preview-support implementation files are intentionally excluded from that policy.

## User and developer impact

- Xcode canvases render deterministic, representative application states without requiring a live Transmission server.
- Interactive server and settings previews can be exercised without changing real credentials or preferences.
- iOS and macOS previews use the same domain fixtures while retaining platform-appropriate UI composition.
- Future view files receive an automated reminder to include preview coverage.
- Production behavior remains unchanged because all injected dependencies default to their existing live implementations.

## Validation

- iOS Debug build: passed
- macOS Debug build: passed
- iOS Release build: passed
- macOS Release build: passed
- SwiftLint: passed
- `git diff --check`: passed
- colocated preview coverage: 62 of 62 SwiftUI view source files
- full macOS test suite: 204 tests passed before the final dependency-isolation refinements; the final test target compiles successfully
- final autoreview: clean, zero actionable findings, 0.90 confidence

A final local XCTest rerun was unable to reach test discovery because the app test host blocked during the pre-existing production bootstrap while Foundation opened this machine's existing App Group container. Sampling confirmed the block occurred in `HostRepository.bootstrap()`/App Group file writing rather than in the test bundle or preview implementation.

Closes #30