### PR TITLE
Restore iPhone torrent navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ When adding new code:
 ## Branches, Commits, and Pull Requests
 
 - Use plain lowercase kebab-case for branch names. Keep names descriptive and do not include issue numbers, prefixes, or namespaces such as `feature/`, `fix/`, usernames, or agent names.
+- Before every commit or amend, show the exact current diff and validation, then get explicit approval. Branch or pull-request requests are not commit approval; later changes require fresh approval.
+- Never amend, rebase, squash, reset, rewrite history, or force-push without explicit approval for that exact operation.
 - Write commit messages entirely lowercase. Use the imperative mood for the subject, keep each commit focused on one logical change, do not use type or scope prefixes, and do not end the subject with a period. Add a body when the reason or important tradeoffs are not clear from the subject.
 - Keep each pull request focused on one coherent change.
 - Write concise, specific, imperative pull request titles in sentence case. Do not use prefixes or trailing periods, and make the title understandable without the branch name.

--- a/BitDream.xcodeproj/project.pbxproj
+++ b/BitDream.xcodeproj/project.pbxproj
@@ -498,7 +498,6 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
@@ -511,7 +510,8 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				"TARGETED_DEVICE_FAMILY[sdk=iphoneos*]" = 1;
+				"TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]" = 1;
 			};
 			name = Debug;
 		};
@@ -548,7 +548,6 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
@@ -562,7 +561,8 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				"TARGETED_DEVICE_FAMILY[sdk=iphoneos*]" = 1;
+				"TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]" = 1;
 			};
 			name = Release;
 		};
@@ -603,7 +603,8 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				"TARGETED_DEVICE_FAMILY[sdk=iphoneos*]" = 1;
+				"TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]" = 1;
 			};
 			name = Debug;
 		};
@@ -648,7 +649,8 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				"TARGETED_DEVICE_FAMILY[sdk=iphoneos*]" = 1;
+				"TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]" = 1;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/BitDream/Views/Shared/TorrentListRow.swift
+++ b/BitDream/Views/Shared/TorrentListRow.swift
@@ -12,8 +12,7 @@ struct TorrentListRow: View {
         iOSTorrentListRow(
             torrent: torrent,
             store: store,
-            showContentTypeIcons: showContentTypeIcons,
-            destinationID: nil
+            showContentTypeIcons: showContentTypeIcons
         )
         #elseif os(macOS)
         macOSTorrentListExpanded(torrent: torrent, store: store, selectedTorrents: selectedTorrents, showContentTypeIcons: showContentTypeIcons)

--- a/BitDream/Views/iOS/iOSContentView.swift
+++ b/BitDream/Views/iOS/iOSContentView.swift
@@ -3,14 +3,11 @@ import Foundation
 
 #if os(iOS)
 struct iOSContentView: View {
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-
     let hosts: [Host]
     @ObservedObject var store: TransmissionStore
     private let userDefaults: UserDefaults
 
-    // Store the selected torrent ID
-    @State private var selectedTorrentID: Int?
+    @State private var torrentPath: [Int] = []
 
     @State private var sortProperty: SortProperty
     @State private var sortOrder: SortOrder
@@ -34,22 +31,23 @@ struct iOSContentView: View {
     }
 
     var body: some View {
-        Group {
-            if horizontalSizeClass == .compact {
-                compactNavigation
-            } else {
-                regularNavigation
-            }
+        NavigationStack(path: $torrentPath) {
+            torrentListScreen
+                .navigationDestination(for: Int.self) { torrentID in
+                    if let torrent = store.torrents.first(where: { $0.id == torrentID }) {
+                        TorrentDetail(store: store, torrent: torrent)
+                    }
+                }
         }
         .onChange(of: store.availableLabels) { _, availableLabels in
             reconcileSelectedLabels(with: availableLabels)
         }
         .onChange(of: store.host?.serverID) { _, _ in
             labelFilter.clear()
-            selectedTorrentID = nil
+            torrentPath.removeAll()
         }
         .onChange(of: store.torrents.map(\.id)) { _, torrentIDs in
-            reconcileSelection(with: torrentIDs)
+            reconcileNavigationPath(with: torrentIDs)
         }
         .sheet(isPresented: $store.setup, content: {
             iOSServerEditor(store: store, hosts: hosts, host: nil)
@@ -71,29 +69,6 @@ struct iOSContentView: View {
 }
 
 private extension iOSContentView {
-    var compactNavigation: some View {
-        NavigationStack(path: torrentPath) {
-            torrentListScreen
-                .navigationDestination(for: Int.self) { torrentID in
-                    if let torrent = store.torrents.first(where: { $0.id == torrentID }) {
-                        TorrentDetail(store: store, torrent: torrent)
-                    }
-                }
-        }
-    }
-
-    var regularNavigation: some View {
-        NavigationSplitView {
-            torrentListScreen
-        } detail: {
-            if let selectedTorrent {
-                TorrentDetail(store: store, torrent: selectedTorrent)
-            } else {
-                Text("Select a Dream")
-            }
-        }
-    }
-
     var torrentListScreen: some View {
         VStack(spacing: 0) {
             StatsHeaderView(store: store)
@@ -142,52 +117,19 @@ private extension iOSContentView {
         )
     }
 
-    var selectedTorrent: Torrent? {
-        guard let selectedTorrentID else { return nil }
-        return store.torrents.first { $0.id == selectedTorrentID }
-    }
-
-    var torrentPath: Binding<[Int]> {
-        Binding(
-            get: { selectedTorrentID.map { [$0] } ?? [] },
-            set: { selectedTorrentID = $0.last }
-        )
-    }
-
-    @ViewBuilder
     var torrentList: some View {
-        if horizontalSizeClass == .compact {
-            List {
-                compactTorrentRows
-            }
-        } else {
-            List(selection: $selectedTorrentID) {
-                regularTorrentRows
-            }
+        List {
+            torrentRows
         }
     }
 
-    var compactTorrentRows: some View {
-        Group {
-            if store.torrents.isEmpty {
-                emptyTorrentList
-            } else {
-                ForEach(displayedTorrents, id: \.id) { torrent in
-                    torrentRow(for: torrent, destinationID: torrent.id)
-                        .listRowSeparator(.visible)
-                }
-            }
-        }
-    }
-
-    var regularTorrentRows: some View {
+    var torrentRows: some View {
         Group {
             if store.torrents.isEmpty {
                 emptyTorrentList
             } else {
                 ForEach(displayedTorrents, id: \.id) { torrent in
                     torrentRow(for: torrent)
-                        .tag(torrent.id)
                         .listRowSeparator(.visible)
                 }
             }
@@ -200,12 +142,11 @@ private extension iOSContentView {
             .padding()
     }
 
-    func torrentRow(for torrent: Torrent, destinationID: Int? = nil) -> some View {
+    func torrentRow(for torrent: Torrent) -> some View {
         iOSTorrentListRow(
             torrent: torrent,
             store: store,
-            showContentTypeIcons: showContentTypeIcons,
-            destinationID: destinationID
+            showContentTypeIcons: showContentTypeIcons
         )
     }
 
@@ -307,9 +248,9 @@ private extension iOSContentView {
         }
     }
 
-    func reconcileSelection(with torrentIDs: [Int]) {
-        guard let selectedTorrentID, !torrentIDs.contains(selectedTorrentID) else { return }
-        self.selectedTorrentID = nil
+    func reconcileNavigationPath(with torrentIDs: [Int]) {
+        let availableTorrentIDs = Set(torrentIDs)
+        torrentPath.removeAll { !availableTorrentIDs.contains($0) }
     }
 
     var hasActiveFilters: Bool {

--- a/BitDream/Views/iOS/iOSTorrentDetail.swift
+++ b/BitDream/Views/iOS/iOSTorrentDetail.swift
@@ -131,7 +131,7 @@ struct iOSTorrentDetail: View {
     }
 
     private func renameSheet() -> some View {
-        NavigationView {
+        NavigationStack {
             IOSTorrentRenameSheet(
                 torrent: torrent,
                 store: store,
@@ -143,7 +143,7 @@ struct iOSTorrentDetail: View {
     }
 
     private func moveSheet() -> some View {
-        NavigationView {
+        NavigationStack {
             IOSTorrentMoveSheet(
                 torrent: torrent,
                 store: store,
@@ -156,7 +156,7 @@ struct iOSTorrentDetail: View {
     }
 
     private func labelSheet() -> some View {
-        NavigationView {
+        NavigationStack {
             iOSLabelEditView(
                 labelInput: $labelInput,
                 existingLabels: torrent.labels,
@@ -269,126 +269,124 @@ private struct IOSTorrentDetailContent<FilesDestination: View, PeersDestination:
     let onRetryPiecesLoad: () -> Void
 
     var body: some View {
-        NavigationStack {
-            VStack {
-                TorrentDetailHeaderView(torrent: torrent)
+        VStack {
+            TorrentDetailHeaderView(torrent: torrent)
 
-                Form {
-                    Section(header: Text("General")) {
-                        HStack(alignment: .top) {
-                            Text("Name")
-                            Spacer(minLength: 50)
-                            Text(torrent.name)
-                                .foregroundColor(.gray)
-                                .multilineTextAlignment(.trailing)
-                                .lineLimit(5)
-                        }
-                        HStack {
-                            Text("Status")
-                            Spacer()
-                            TorrentStatusBadge(torrent: torrent)
-                        }
-                        HStack {
-                            Text("Date Added")
-                            Spacer()
-                            Text(details.addedDate)
-                                .foregroundColor(.gray)
-                        }
+            Form {
+                Section(header: Text("General")) {
+                    HStack(alignment: .top) {
+                        Text("Name")
+                        Spacer(minLength: 50)
+                        Text(torrent.name)
+                            .foregroundColor(.gray)
+                            .multilineTextAlignment(.trailing)
+                            .lineLimit(5)
+                    }
+                    HStack {
+                        Text("Status")
+                        Spacer()
+                        TorrentStatusBadge(torrent: torrent)
+                    }
+                    HStack {
+                        Text("Date Added")
+                        Spacer()
+                        Text(details.addedDate)
+                            .foregroundColor(.gray)
+                    }
 
-                        NavigationLink {
-                            filesDestination
-                        } label: {
-                            LabeledContent(
-                                "Files",
-                                value: NumberFormatter.localizedString(
-                                    from: NSNumber(value: supplementalPayload.files.count),
-                                    number: .decimal
-                                )
+                    NavigationLink {
+                        filesDestination
+                    } label: {
+                        LabeledContent(
+                            "Files",
+                            value: NumberFormatter.localizedString(
+                                from: NSNumber(value: supplementalPayload.files.count),
+                                number: .decimal
                             )
-                        }
-
-                        NavigationLink {
-                            peersDestination
-                        } label: {
-                            LabeledContent("Peers", value: "\(supplementalPayload.peers.count)")
-                        }
-                    }
-
-                    Section(header: Text("Stats")) {
-                        HStack {
-                            Text("Size When Done")
-                            Spacer()
-                            Text(details.sizeWhenDoneFormatted)
-                                .foregroundColor(.gray)
-                        }
-                        HStack {
-                            Text("Progress")
-                            Spacer()
-                            Text(details.percentComplete)
-                                .foregroundColor(.gray)
-                        }
-                        HStack {
-                            Text("Downloaded")
-                            Spacer()
-                            Text(details.downloadedFormatted)
-                                .foregroundColor(.gray)
-                        }
-                        HStack {
-                            Text("Uploaded")
-                            Spacer()
-                            Text(details.uploadedFormatted)
-                                .foregroundColor(.gray)
-                        }
-                        HStack {
-                            Text("Upload Ratio")
-                            Spacer()
-                            Text(details.uploadRatio)
-                                .foregroundColor(.gray)
-                        }
-                    }
-
-                    Section(header: Text("Pieces")) {
-                        IOSTorrentPiecesSectionContent(
-                            state: piecesSectionState,
-                            onRetry: onRetryPiecesLoad
                         )
+                    }
+
+                    NavigationLink {
+                        peersDestination
+                    } label: {
+                        LabeledContent("Peers", value: "\(supplementalPayload.peers.count)")
+                    }
+                }
+
+                Section(header: Text("Stats")) {
+                    HStack {
+                        Text("Size When Done")
+                        Spacer()
+                        Text(details.sizeWhenDoneFormatted)
+                            .foregroundColor(.gray)
+                    }
+                    HStack {
+                        Text("Progress")
+                        Spacer()
+                        Text(details.percentComplete)
+                            .foregroundColor(.gray)
+                    }
+                    HStack {
+                        Text("Downloaded")
+                        Spacer()
+                        Text(details.downloadedFormatted)
+                            .foregroundColor(.gray)
+                    }
+                    HStack {
+                        Text("Uploaded")
+                        Spacer()
+                        Text(details.uploadedFormatted)
+                            .foregroundColor(.gray)
+                    }
+                    HStack {
+                        Text("Upload Ratio")
+                        Spacer()
+                        Text(details.uploadRatio)
+                            .foregroundColor(.gray)
+                    }
+                }
+
+                Section(header: Text("Pieces")) {
+                    IOSTorrentPiecesSectionContent(
+                        state: piecesSectionState,
+                        onRetry: onRetryPiecesLoad
+                    )
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                }
+
+                Section(header: Text("Additional Info")) {
+                    HStack {
+                        Text("Availability")
+                        Spacer()
+                        Text(details.percentAvailable)
+                            .foregroundColor(.gray)
+                    }
+                    HStack {
+                        Text("Last Activity")
+                        Spacer()
+                        Text(details.activityDate)
+                            .foregroundColor(.gray)
+                    }
+                }
+
+                if !torrent.labels.isEmpty {
+                    Section(header: Text("Labels")) {
+                        FlowLayout(spacing: 6) {
+                            ForEach(torrent.labels.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }, id: \.self) { label in
+                                DetailViewLabelTag(label: label, isLarge: false)
+                            }
+                        }
+                        .padding(.vertical, 8)
                         .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                     }
+                }
 
-                    Section(header: Text("Additional Info")) {
+                Button(role: .destructive, action: onDelete) {
+                    HStack {
                         HStack {
-                            Text("Availability")
+                            Image(systemName: "trash")
+                            Text("Delete…")
                             Spacer()
-                            Text(details.percentAvailable)
-                                .foregroundColor(.gray)
-                        }
-                        HStack {
-                            Text("Last Activity")
-                            Spacer()
-                            Text(details.activityDate)
-                                .foregroundColor(.gray)
-                        }
-                    }
-
-                    if !torrent.labels.isEmpty {
-                        Section(header: Text("Labels")) {
-                            FlowLayout(spacing: 6) {
-                                ForEach(torrent.labels.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }, id: \.self) { label in
-                                    DetailViewLabelTag(label: label, isLarge: false)
-                                }
-                            }
-                            .padding(.vertical, 8)
-                            .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
-                        }
-                    }
-
-                    Button(role: .destructive, action: onDelete) {
-                        HStack {
-                            HStack {
-                                Image(systemName: "trash")
-                                Text("Delete…")
-                                Spacer()
-                            }
                         }
                     }
                 }

--- a/BitDream/Views/iOS/iOSTorrentListRow.swift
+++ b/BitDream/Views/iOS/iOSTorrentListRow.swift
@@ -6,7 +6,6 @@ struct iOSTorrentListRow: View {
     var torrent: Torrent
     var store: TransmissionStore
     var showContentTypeIcons: Bool
-    var destinationID: Int?
 
     @State private var deleteDialog: Bool = false
     @State private var labelDialog: Bool = false
@@ -20,42 +19,33 @@ struct iOSTorrentListRow: View {
     @State private var errorMessage = ""
 
     var body: some View {
-        listRow
-            .swipeActions(edge: .trailing) {
-                swipeActions
-            }
-            .contextMenu { actionsMenu }
-            .id(torrent.id)
-            .confirmationDialog(
-                "Delete Torrent",
-                isPresented: $deleteDialog,
-                titleVisibility: .visible
-            ) {
-                Button("Delete file(s)", role: .destructive) {
-                    performDelete(erase: true)
-                }
-                Button("Remove from list only") {
-                    performDelete(erase: false)
-                }
-                Button("Cancel", role: .cancel) {}
-            } message: {
-                Text("Do you want to delete the file(s) from the disk?")
-            }
-            .transmissionErrorAlert(isPresented: $showingError, message: errorMessage)
-            .sheet(isPresented: $renameDialog, content: renameSheet)
-            .sheet(isPresented: $moveDialog, content: moveSheet)
-            .sheet(isPresented: $labelDialog, content: labelSheet)
-    }
-
-    @ViewBuilder
-    private var listRow: some View {
-        if let destinationID {
-            NavigationLink(value: destinationID) {
-                paddedRowContent
-            }
-        } else {
+        NavigationLink(value: torrent.id) {
             paddedRowContent
         }
+        .swipeActions(edge: .trailing) {
+            swipeActions
+        }
+        .contextMenu { actionsMenu }
+        .id(torrent.id)
+        .confirmationDialog(
+            "Delete Torrent",
+            isPresented: $deleteDialog,
+            titleVisibility: .visible
+        ) {
+            Button("Delete file(s)", role: .destructive) {
+                performDelete(erase: true)
+            }
+            Button("Remove from list only") {
+                performDelete(erase: false)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Do you want to delete the file(s) from the disk?")
+        }
+        .transmissionErrorAlert(isPresented: $showingError, message: errorMessage)
+        .sheet(isPresented: $renameDialog, content: renameSheet)
+        .sheet(isPresented: $moveDialog, content: moveSheet)
+        .sheet(isPresented: $labelDialog, content: labelSheet)
     }
 
     private var paddedRowContent: some View {
@@ -127,7 +117,7 @@ struct iOSTorrentListRow: View {
     }
 
     private func renameSheet() -> some View {
-        NavigationView {
+        NavigationStack {
             IOSTorrentRenameSheet(
                 torrent: torrent,
                 store: store,
@@ -139,7 +129,7 @@ struct iOSTorrentListRow: View {
     }
 
     private func moveSheet() -> some View {
-        NavigationView {
+        NavigationStack {
             IOSTorrentMoveSheet(
                 torrent: torrent,
                 store: store,
@@ -152,7 +142,7 @@ struct iOSTorrentListRow: View {
     }
 
     private func labelSheet() -> some View {
-        NavigationView {
+        NavigationStack {
             iOSLabelEditView(
                 labelInput: $labelInput,
                 existingLabels: torrent.labels,
@@ -607,8 +597,7 @@ struct iOSTorrentListRow: View {
         iOSTorrentListRow(
             torrent: PreviewFixtures.torrents[0],
             store: environment.store,
-            showContentTypeIcons: true,
-            destinationID: nil
+            showContentTypeIcons: true
         )
         .padding()
     }


### PR DESCRIPTION
## What Changed

- replace the competing compact and regular navigation hierarchies with one root `NavigationStack`
- store the torrent navigation path directly and use `NavigationLink(value:)` for every torrent row
- remove the nested navigation stack from torrent detail so detail, Files, and Peers share one navigation owner
- clear stale routes when the active server changes or a torrent disappears
- configure the app and widget targets as iPhone-only for iOS device and simulator SDKs while leaving native macOS settings untouched
- replace the affected legacy `NavigationView` sheet containers with `NavigationStack`

## Why

PR #110 introduced separate size-class navigation hierarchies. On iPhone, a computed path binding wrote stack changes back into list selection while the pushed detail created another navigation stack. Those competing owners caused the app to repeatedly push and pop a blank detail screen.

The first revision of this fix restored `NavigationSplitView`, but BitDream currently supports iPhone rather than iPad. It also left plain tagged rows that did not provide an explicit compact-width navigation action. The final design models the supported product directly: one iPhone navigation stack with a real stored path and value-based links.

PR #111 exposed the failure while detail refreshes were active but was not the navigation root cause.

Related: #110, #111

## UI Changes

Selecting a torrent on iPhone now pushes its detail exactly once. Back navigation returns to the torrent list, while Files and Peers continue forward in the same stack. The iOS app and widget are no longer distributed as iPad targets.

## Validation

- iPhone-only iOS 26 debug build with signing disabled
- native macOS debug build
- macOS test suite: 206 tests passed
- verified iOS `TARGETED_DEVICE_FAMILY = 1` and no macOS device-family override
- `swiftlint lint --quiet`
- `git diff --check`