### PR TITLE
Restore zero transfer rate formatting

### DIFF
--- a/BitDream/Formatting.swift
+++ b/BitDream/Formatting.swift
@@ -15,7 +15,10 @@ private let byteCountFormatStyle = ByteCountFormatStyle(
 /// Shared byte formatting helper using modern format style.
 /// Round up 1 to 999 bytes to 1 kB.
 public func formatByteCount(_ bytes: Int64) -> String {
-    String(formattedByteCount(bytes).characters)
+    if bytes == 0 {
+        return "0 kB"
+    }
+    return String(formattedByteCount(bytes).characters)
 }
 
 /// Shared speed formatting helper (bytes per second -> short string).

--- a/BitDreamTests/Formatting/FormattingTests.swift
+++ b/BitDreamTests/Formatting/FormattingTests.swift
@@ -51,6 +51,11 @@ final class FormattingTests: XCTestCase {
 
     // MARK: - formatByteCount / formatSpeed
 
+    func testZeroUsesKilobyteUnit() {
+        XCTAssertEqual(formatByteCount(0), "0 kB")
+        XCTAssertEqual(formatSpeed(0), "0 kB/s")
+    }
+
     func testFormatByteCountRoundsSubKilobyteUpToOneKilobyte() {
         XCTAssertEqual(formatByteCount(500), formatByteCount(1_000))
     }


### PR DESCRIPTION
## What Changed

- Restore the explicit `0 kB` representation for zero byte counts.
- Add regression coverage for both byte-count and transfer-rate formatting.

## Why

The dock transfer-rate badge work routed zero through `ByteCountFormatStyle`, which selects its localized byte unit for zero and caused transfer rates to display as `0 bytes/s`.

## UI Changes

Zero transfer rates display as `0 kB/s` again instead of `0 bytes/s`.

## Validation

- macOS test suite: 207 tests passed
- iOS unsigned build succeeded
- SwiftLint passed
- `git diff --check` passed