### PR TITLE
Add Done button to label filters

### DIFF
--- a/BitDream/Views/iOS/iOSFilterAndSortView.swift
+++ b/BitDream/Views/iOS/iOSFilterAndSortView.swift
@@ -29,7 +29,8 @@ struct iOSFilterAndSortView: View {
                             labelFilter: $labelFilter,
                             availableLabels: availableLabels,
                             labelCounts: labelCounts,
-                            noLabelCount: noLabelCount
+                            noLabelCount: noLabelCount,
+                            onDone: dismiss.callAsFunction
                         )
                     } label: {
                         LabeledContent("Labels", value: labelSelectionSummary)
@@ -55,7 +56,7 @@ struct iOSFilterAndSortView: View {
             .navigationTitle("Filter & Sort")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
+                ToolbarItem(id: "filter-and-sort-done", placement: .confirmationAction) {
                     Button("Done", action: dismiss.callAsFunction)
                 }
             }
@@ -92,6 +93,7 @@ private struct iOSLabelFilterView: View {
     let availableLabels: [String]
     let labelCounts: [String: Int]
     let noLabelCount: Int
+    let onDone: () -> Void
 
     var body: some View {
         List {
@@ -139,6 +141,11 @@ private struct iOSLabelFilterView: View {
         }
         .navigationTitle("Labels")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(id: "label-filter-done", placement: .confirmationAction) {
+                Button("Done", action: onDone)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## What Changed

- Add a Done button to the iOS Labels filter destination.
- Keep Back for navigation while Done dismisses the entire Filter & Sort sheet.
- Give the root and destination toolbar items stable IDs so Done remains visible across repeated navigation.

## Why

The Labels filter only exposed Back, which could return to Filter & Sort but could not directly finish and dismiss the sheet.

## UI Changes

The Labels filter now shows Back on the leading side and Done on the trailing side.

## Validation

- iOS 26.5 simulator build and repeated-navigation verification
- Generic iOS build
- Generic macOS build
- 206 macOS tests, 0 failures
- SwiftLint
- `git diff --check`