### PR TITLE
Add iOS sidebar drawer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ xcuserdata/
 # Visual Studio Code
 .vscode
 
+# Local agent worktrees
+.claude/
+
 ## Build artifacts
 build/
 .build/

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
 excluded:
   - build
   - .build
+  - .claude
   # TODO: Refactor these files and remove the temporary lint exclusion.
   - BitDream/TransmissionStore.swift
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ When adding new code:
 - Before every commit or amend, show the exact current diff and validation, then get explicit approval. Branch or pull-request requests are not commit approval; later changes require fresh approval.
 - Never amend, rebase, squash, reset, rewrite history, or force-push without explicit approval for that exact operation.
 - Write commit messages entirely lowercase. Use the imperative mood for the subject, keep each commit focused on one logical change, do not use type or scope prefixes, and do not end the subject with a period. Add a body when the reason or important tradeoffs are not clear from the subject.
+- Never add `Co-Authored-By` trailers or any other AI/agent attribution to commits, pull request descriptions, or code. Commits are authored by the maintainer alone.
 - Keep each pull request focused on one coherent change.
 - Write concise, specific, imperative pull request titles in sentence case. Do not use prefixes or trailing periods, and make the title understandable without the branch name.
 - Pull request descriptions must include `What Changed`, `Why`, and `Validation`. Include `UI Changes` only when the pull request changes the UI. Keep descriptions concise, self-contained, complete, and accurate to the final diff.

--- a/BitDream/BitDreamApp.swift
+++ b/BitDream/BitDreamApp.swift
@@ -20,6 +20,7 @@ struct BitDreamApp: App {
     @StateObject private var menuBarStatusItemController = MenuBarStatusItemBridge()
     @StateObject private var dockBadgeController = DockBadgeController()
     @StateObject private var appUpdater = AppUpdater()
+    @StateObject private var serverEditingCoordinator = MacOSServerEditingCoordinator()
     #endif
 
     // HUD state for macOS appearance toggle feedback
@@ -91,6 +92,7 @@ private extension BitDreamApp {
         Window("BitDream", id: "main") {
             ContentView()
                 .environmentObject(store) // Pass the shared store to the ContentView
+                .environmentObject(serverEditingCoordinator)
                 .accentColor(themeManager.accentColor) // Apply the accent color to the entire app
                 .environmentObject(themeManager) // Pass the ThemeManager to all views
                 .immediateTheme(manager: themeManager)
@@ -250,6 +252,7 @@ private extension BitDreamApp {
         Window("Manage Servers", id: "manage-servers") {
             macOSManageServersWindow()
                 .environmentObject(store)
+                .environmentObject(serverEditingCoordinator)
                 .tint(themeManager.accentColor)
                 .environmentObject(themeManager)
                 .immediateTheme(manager: themeManager)

--- a/BitDream/PreviewSupport/PreviewSupport.swift
+++ b/BitDream/PreviewSupport/PreviewSupport.swift
@@ -25,6 +25,7 @@ final class PreviewEnvironment {
     #endif
     #if os(macOS)
     let appUpdater: AppUpdater
+    let serverEditingCoordinator: MacOSServerEditingCoordinator
     #endif
 
     init(scenario: PreviewScenario = .connected) {
@@ -48,6 +49,7 @@ final class PreviewEnvironment {
         #endif
         #if os(macOS)
         self.appUpdater = AppUpdater(updatesEnabled: false)
+        self.serverEditingCoordinator = MacOSServerEditingCoordinator()
         #endif
     }
 
@@ -84,6 +86,7 @@ struct PreviewContainer<Content: View>: View {
         #if os(macOS)
         content(previewEnvironment)
             .environmentObject(previewEnvironment.appUpdater)
+            .environmentObject(previewEnvironment.serverEditingCoordinator)
         #elseif os(iOS)
         content(previewEnvironment)
             .environmentObject(previewEnvironment.appIconManager)

--- a/BitDream/Views/iOS/iOSContentView.swift
+++ b/BitDream/Views/iOS/iOSContentView.swift
@@ -35,7 +35,7 @@ struct iOSContentView: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let drawerWidth = proxy.size.width * 0.75
+            let drawerWidth = proxy.size.width * 0.77
             let progress = sidebarProgress(drawerWidth: drawerWidth)
 
             ZStack(alignment: .leading) {
@@ -92,7 +92,7 @@ private extension iOSContentView {
             torrentCount: { torrentCount(for: $0) },
             onSelectHost: { host in
                 store.setHost(host: host)
-                closeSidebar()
+                closeSidebarAfterSelection()
             },
             onAddServer: {
                 store.setup = true
@@ -121,12 +121,14 @@ private extension iOSContentView {
                 }
         }
         .onChange(of: sidebarSelection) { _, _ in
-            closeSidebar()
+            closeSidebarAfterSelection()
         }
         .overlay {
             if progress > 0 {
-                // Invisible tap/drag catcher; the pushed card intentionally stays undimmed
-                Color.clear
+                // White scrim fades the card toward the background; also catches taps/drags to close
+                Color(.systemBackground)
+                    .opacity(0.55 * progress)
+                    .ignoresSafeArea()
                     .contentShape(.rect)
                     .onTapGesture {
                         closeSidebar()
@@ -191,6 +193,14 @@ private extension iOSContentView {
         guard isSidebarOpen else { return }
         withAnimation(drawerAnimation) {
             isSidebarOpen = false
+        }
+    }
+
+    /// Lets the row's selection highlight land before the drawer slides away.
+    func closeSidebarAfterSelection() {
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(90))
+            closeSidebar()
         }
     }
 }

--- a/BitDream/Views/iOS/iOSContentView.swift
+++ b/BitDream/Views/iOS/iOSContentView.swift
@@ -405,27 +405,18 @@ private extension iOSContentView {
 /// Sidebar toggle glyph: a long line over a shorter line.
 /// Template image so the toolbar tints it like an SF Symbol.
 struct SidebarToggleGlyph: View {
-    var body: some View {
-        Image(uiImage: Self.glyph)
-    }
+    private static let lineHeight: CGFloat = 2.5
+    private static let spacing: CGFloat = 4.5
 
-    private static let glyph: UIImage = {
-        let lineHeight: CGFloat = 2.5
-        let spacing: CGFloat = 4.5
-        let size = CGSize(width: 17, height: lineHeight * 2 + spacing)
-        let image = UIGraphicsImageRenderer(size: size).image { _ in
-            UIColor.black.setFill()
-            UIBezierPath(
-                roundedRect: CGRect(x: 0, y: 0, width: 17, height: lineHeight),
-                cornerRadius: lineHeight / 2
-            ).fill()
-            UIBezierPath(
-                roundedRect: CGRect(x: 0, y: lineHeight + spacing, width: 11, height: lineHeight),
-                cornerRadius: lineHeight / 2
-            ).fill()
+    var body: some View {
+        Image(size: CGSize(width: 17, height: Self.lineHeight * 2 + Self.spacing)) { context in
+            let top = Capsule().path(in: CGRect(x: 0, y: 0, width: 17, height: Self.lineHeight))
+            let bottom = Capsule().path(in: CGRect(x: 0, y: Self.lineHeight + Self.spacing, width: 11, height: Self.lineHeight))
+            context.fill(top, with: .color(.black))
+            context.fill(bottom, with: .color(.black))
         }
-        return image.withRenderingMode(.alwaysTemplate)
-    }()
+        .renderingMode(.template)
+    }
 }
 
 #if DEBUG

--- a/BitDream/Views/iOS/iOSContentView.swift
+++ b/BitDream/Views/iOS/iOSContentView.swift
@@ -11,11 +11,14 @@ struct iOSContentView: View {
 
     @State private var sortProperty: SortProperty
     @State private var sortOrder: SortOrder
-    @State private var filterBySelection: [TorrentStatusCalc] = TorrentStatusCalc.allCases
+    @State private var sidebarSelection: SidebarSelection = .allDreams
     @State private var labelFilter = TorrentLabelFilter()
     @AppStorage(UserDefaultsKeys.showContentTypeIcons) private var showContentTypeIcons = AppDefaults.showContentTypeIcons
     @State private var searchText: String = ""
     @State private var showPrefs: Bool = false
+
+    @State private var isSidebarOpen = false
+    @State private var sidebarDragOffset: CGFloat = 0
 
     init(hosts: [Host], store: TransmissionStore, userDefaults: UserDefaults = .standard) {
         self.hosts = hosts
@@ -31,13 +34,18 @@ struct iOSContentView: View {
     }
 
     var body: some View {
-        NavigationStack(path: $torrentPath) {
-            torrentListScreen
-                .navigationDestination(for: Int.self) { torrentID in
-                    if let torrent = store.torrents.first(where: { $0.id == torrentID }) {
-                        TorrentDetail(store: store, torrent: torrent)
-                    }
-                }
+        GeometryReader { proxy in
+            let drawerWidth = proxy.size.width * 0.75
+            let progress = sidebarProgress(drawerWidth: drawerWidth)
+
+            ZStack(alignment: .leading) {
+                Color(.systemBackground)
+
+                sidebar(drawerWidth: drawerWidth, progress: progress, safeAreaInsets: proxy.safeAreaInsets)
+
+                mainContent(drawerWidth: drawerWidth, progress: progress)
+            }
+            .ignoresSafeArea()
         }
         .onChange(of: store.availableLabels) { _, availableLabels in
             reconcileSelectedLabels(with: availableLabels)
@@ -68,6 +76,127 @@ struct iOSContentView: View {
     }
 }
 
+// MARK: - Drawer Container
+
+private extension iOSContentView {
+    func sidebarProgress(drawerWidth: CGFloat) -> CGFloat {
+        let base: CGFloat = isSidebarOpen ? drawerWidth : 0
+        return min(max((base + sidebarDragOffset) / drawerWidth, 0), 1)
+    }
+
+    func sidebar(drawerWidth: CGFloat, progress: CGFloat, safeAreaInsets: EdgeInsets) -> some View {
+        iOSSidebarView(
+            hosts: hosts,
+            sidebarSelection: $sidebarSelection,
+            selectedHostID: store.host?.serverID,
+            torrentCount: { torrentCount(for: $0) },
+            onSelectHost: { host in
+                store.setHost(host: host)
+                closeSidebar()
+            },
+            onAddServer: {
+                store.setup = true
+            },
+            onManageServers: {
+                store.editServers = true
+            },
+            onOpenSettings: {
+                store.showSettings = true
+            }
+        )
+        .padding(.top, safeAreaInsets.top)
+        .padding(.bottom, max(0, safeAreaInsets.bottom - 6))
+        .frame(width: drawerWidth)
+        .offset(x: -drawerWidth * 0.3 * (1 - progress))
+        .accessibilityHidden(progress == 0)
+    }
+
+    func mainContent(drawerWidth: CGFloat, progress: CGFloat) -> some View {
+        NavigationStack(path: $torrentPath) {
+            torrentListScreen
+                .navigationDestination(for: Int.self) { torrentID in
+                    if let torrent = store.torrents.first(where: { $0.id == torrentID }) {
+                        TorrentDetail(store: store, torrent: torrent)
+                    }
+                }
+        }
+        .onChange(of: sidebarSelection) { _, _ in
+            closeSidebar()
+        }
+        .overlay {
+            if progress > 0 {
+                // Invisible tap/drag catcher; the pushed card intentionally stays undimmed
+                Color.clear
+                    .contentShape(.rect)
+                    .onTapGesture {
+                        closeSidebar()
+                    }
+                    .gesture(closeDragGesture(drawerWidth: drawerWidth))
+            }
+        }
+        .overlay(alignment: .leading) {
+            if !isSidebarOpen && torrentPath.isEmpty {
+                Color.clear
+                    .frame(width: 20)
+                    .contentShape(.rect)
+                    .gesture(openDragGesture(drawerWidth: drawerWidth))
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 32 * progress, style: .continuous))
+        .shadow(color: .black.opacity(0.12 * progress), radius: 12)
+        .offset(x: drawerWidth * progress)
+    }
+
+    func openDragGesture(drawerWidth: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 10)
+            .onChanged { value in
+                sidebarDragOffset = max(0, value.translation.width)
+            }
+            .onEnded { value in
+                let shouldOpen = value.translation.width > drawerWidth * 0.25
+                    || value.predictedEndTranslation.width > drawerWidth * 0.5
+                withAnimation(drawerAnimation) {
+                    isSidebarOpen = shouldOpen
+                    sidebarDragOffset = 0
+                }
+            }
+    }
+
+    func closeDragGesture(drawerWidth: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 10)
+            .onChanged { value in
+                sidebarDragOffset = min(0, value.translation.width)
+            }
+            .onEnded { value in
+                let shouldClose = value.translation.width < -drawerWidth * 0.25
+                    || value.predictedEndTranslation.width < -drawerWidth * 0.5
+                withAnimation(drawerAnimation) {
+                    isSidebarOpen = !shouldClose
+                    sidebarDragOffset = 0
+                }
+            }
+    }
+
+    var drawerAnimation: Animation {
+        .snappy(duration: 0.32, extraBounce: 0)
+    }
+
+    func toggleSidebar() {
+        withAnimation(drawerAnimation) {
+            isSidebarOpen.toggle()
+        }
+    }
+
+    func closeSidebar() {
+        guard isSidebarOpen else { return }
+        withAnimation(drawerAnimation) {
+            isSidebarOpen = false
+        }
+    }
+}
+
+// MARK: - Torrent List Screen
+
 private extension iOSContentView {
     var torrentListScreen: some View {
         VStack(spacing: 0) {
@@ -85,14 +214,14 @@ private extension iOSContentView {
             torrentList
                 .listStyle(PlainListStyle())
         }
-        .navigationTitle("Dreams")
+        .navigationTitle(sidebarSelection.rawValue)
         .navigationBarTitleDisplayMode(.inline)
         .refreshable {
             await store.refreshNow()
         }
         .searchable(text: $searchText, prompt: "Search torrents")
         .toolbar {
-            serverToolbarItem
+            sidebarToolbarItem
             actionToolbarItems
             bottomToolbarItems
         }
@@ -108,7 +237,7 @@ private extension iOSContentView {
         filterAndSortTorrents(
             store.torrents,
             options: TorrentDisplayOptions(
-                statusFilter: filterBySelection,
+                statusFilter: sidebarSelection.filter,
                 labelFilter: labelFilter,
                 searchText: searchText,
                 sortProperty: sortProperty,
@@ -150,8 +279,19 @@ private extension iOSContentView {
         )
     }
 
-    var serverToolbarItem: some ToolbarContent {
+    var sidebarToolbarItem: some ToolbarContent {
         ToolbarItem(placement: .topBarLeading) {
+            Button {
+                toggleSidebar()
+            } label: {
+                SidebarToggleGlyph()
+            }
+            .accessibilityLabel("Menu")
+        }
+    }
+
+    var actionToolbarItems: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
             Menu {
                 Button(action: pauseAllTorrents, label: {
                     Label("Pause All", systemImage: "pause")
@@ -162,23 +302,6 @@ private extension iOSContentView {
             } label: {
                 Image(systemName: "ellipsis.circle")
             }
-        }
-    }
-
-    var actionToolbarItems: some ToolbarContent {
-        ToolbarItemGroup(placement: .automatic) {
-            Button {
-                store.editServers = true
-            } label: {
-                Image(systemName: "server.rack")
-            }
-            .accessibilityLabel("Servers")
-
-            Button(action: {
-                store.showSettings.toggle()
-            }, label: {
-                Image(systemName: "gear")
-            })
         }
     }
 
@@ -198,7 +321,6 @@ private extension iOSContentView {
                 .accessibilityValue(hasActiveFilters ? "Active" : "Inactive")
                 .popover(isPresented: $showPrefs) {
                     iOSFilterAndSortView(
-                        statusFilter: $filterBySelection,
                         labelFilter: $labelFilter,
                         sortProperty: $sortProperty,
                         sortOrder: $sortOrder,
@@ -254,7 +376,11 @@ private extension iOSContentView {
     }
 
     var hasActiveFilters: Bool {
-        filterBySelection != TorrentStatusCalc.allCases || labelFilter.isActive
+        labelFilter.isActive
+    }
+
+    func torrentCount(for category: SidebarSelection) -> Int {
+        store.torrents.filtered(by: category.filter).count
     }
 
     var availableLabelCounts: [String: Int] {
@@ -265,9 +391,34 @@ private extension iOSContentView {
         )
     }
 }
-#endif
 
-#if os(iOS) && DEBUG
+/// Sidebar toggle glyph: a long line over a shorter line.
+/// Template image so the toolbar tints it like an SF Symbol.
+struct SidebarToggleGlyph: View {
+    var body: some View {
+        Image(uiImage: Self.glyph)
+    }
+
+    private static let glyph: UIImage = {
+        let lineHeight: CGFloat = 2.5
+        let spacing: CGFloat = 4.5
+        let size = CGSize(width: 17, height: lineHeight * 2 + spacing)
+        let image = UIGraphicsImageRenderer(size: size).image { _ in
+            UIColor.black.setFill()
+            UIBezierPath(
+                roundedRect: CGRect(x: 0, y: 0, width: 17, height: lineHeight),
+                cornerRadius: lineHeight / 2
+            ).fill()
+            UIBezierPath(
+                roundedRect: CGRect(x: 0, y: lineHeight + spacing, width: 11, height: lineHeight),
+                cornerRadius: lineHeight / 2
+            ).fill()
+        }
+        return image.withRenderingMode(.alwaysTemplate)
+    }()
+}
+
+#if DEBUG
 #Preview("iOS Content") {
     PreviewContainer { environment in
         iOSContentView(
@@ -277,4 +428,6 @@ private extension iOSContentView {
         )
     }
 }
+#endif
+
 #endif

--- a/BitDream/Views/iOS/iOSContentView.swift
+++ b/BitDream/Views/iOS/iOSContentView.swift
@@ -16,6 +16,7 @@ struct iOSContentView: View {
     @AppStorage(UserDefaultsKeys.showContentTypeIcons) private var showContentTypeIcons = AppDefaults.showContentTypeIcons
     @State private var searchText: String = ""
     @State private var showPrefs: Bool = false
+    @State private var serverToEdit: Host?
 
     @State private var isSidebarOpen = false
     @State private var sidebarDragOffset: CGFloat = 0
@@ -63,6 +64,9 @@ struct iOSContentView: View {
         .sheet(isPresented: $store.editServers, content: {
             iOSServerList(hosts: hosts, store: store)
         })
+        .sheet(item: $serverToEdit) { host in
+            iOSServerEditor(store: store, hosts: hosts, host: host)
+        }
         .sheet(isPresented: $store.isShowingAddAlert, content: {
             AddTorrent(store: store)
         })
@@ -93,6 +97,9 @@ private extension iOSContentView {
             onSelectHost: { host in
                 store.setHost(host: host)
                 closeSidebarAfterSelection()
+            },
+            onEditServer: { host in
+                serverToEdit = host
             },
             onAddServer: {
                 store.setup = true

--- a/BitDream/Views/iOS/iOSFilterAndSortView.swift
+++ b/BitDream/Views/iOS/iOSFilterAndSortView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 struct iOSFilterAndSortView: View {
     @Environment(\.dismiss) private var dismiss
 
-    @Binding var statusFilter: [TorrentStatusCalc]
     @Binding var labelFilter: TorrentLabelFilter
     @Binding var sortProperty: SortProperty
     @Binding var sortOrder: SortOrder
@@ -17,13 +16,6 @@ struct iOSFilterAndSortView: View {
         NavigationStack {
             List {
                 Section("Filter") {
-                    Picker("Status", selection: statusOptionBinding) {
-                        ForEach(iOSStatusFilterOption.allCases) { option in
-                            Text(option.rawValue).tag(option)
-                        }
-                    }
-                    .pickerStyle(.navigationLink)
-
                     NavigationLink {
                         iOSLabelFilterView(
                             labelFilter: $labelFilter,
@@ -65,15 +57,6 @@ struct iOSFilterAndSortView: View {
 }
 
 private extension iOSFilterAndSortView {
-    var statusOptionBinding: Binding<iOSStatusFilterOption> {
-        Binding(
-            get: {
-                iOSStatusFilterOption.allCases.first { $0.statuses == statusFilter } ?? .all
-            },
-            set: { statusFilter = $0.statuses }
-        )
-    }
-
     var labelSelectionSummary: String {
         switch labelFilter.activeCount {
         case 0:
@@ -208,41 +191,15 @@ private struct iOSNoLabelsFilterRow: View {
     }
 }
 
-private enum iOSStatusFilterOption: String, CaseIterable, Identifiable {
-    case all = "All"
-    case downloading = "Downloading"
-    case complete = "Complete"
-    case paused = "Paused"
-    case excludeComplete = "Exclude Complete"
-
-    var id: Self { self }
-
-    var statuses: [TorrentStatusCalc] {
-        switch self {
-        case .all:
-            return TorrentStatusCalc.allCases
-        case .downloading:
-            return [.downloading]
-        case .complete:
-            return [.complete]
-        case .paused:
-            return [.paused]
-        case .excludeComplete:
-            return TorrentStatusCalc.allCases.filter { $0 != .complete }
-        }
-    }
-}
 #endif
 
 #if os(iOS) && DEBUG
 #Preview("iOS Filter and Sort") {
-    @Previewable @State var statusFilter = TorrentStatusCalc.allCases
     @Previewable @State var labelFilter = TorrentLabelFilter()
     @Previewable @State var sortProperty = SortProperty.name
     @Previewable @State var sortOrder = SortOrder.ascending
 
     iOSFilterAndSortView(
-        statusFilter: $statusFilter,
         labelFilter: $labelFilter,
         sortProperty: $sortProperty,
         sortOrder: $sortOrder,

--- a/BitDream/Views/iOS/iOSSidebarView.swift
+++ b/BitDream/Views/iOS/iOSSidebarView.swift
@@ -48,7 +48,12 @@ struct iOSSidebarView: View {
                             onSelectHost(host)
                         }
                     }
-                    SidebarRow(title: "Add Server", systemImage: "plus", action: onAddServer)
+                    SidebarRow(
+                        title: "Add Server",
+                        systemImage: "plus.circle.fill",
+                        isAction: true,
+                        action: onAddServer
+                    )
                 }
                 .padding(.horizontal, 8)
             }
@@ -106,6 +111,7 @@ private struct SidebarRow: View {
     var badge: Int?
     var isSelected = false
     var showsCheckmark = false
+    var isAction = false
     let action: () -> Void
 
     var body: some View {
@@ -113,7 +119,7 @@ private struct SidebarRow: View {
             HStack(spacing: 12) {
                 Image(systemName: systemImage)
                     .frame(width: 24)
-                    .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
+                    .foregroundStyle((isSelected || isAction) ? Color.accentColor : Color.primary)
 
                 Text(title)
                     .foregroundStyle(.primary)

--- a/BitDream/Views/iOS/iOSSidebarView.swift
+++ b/BitDream/Views/iOS/iOSSidebarView.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+#if os(iOS)
+/// Slide-out drawer content mirroring the macOS sidebar: status filters, servers, and settings.
+struct iOSSidebarView: View {
+    let hosts: [Host]
+    @Binding var sidebarSelection: SidebarSelection
+    let selectedHostID: String?
+    let torrentCount: (SidebarSelection) -> Int
+    let onSelectHost: (Host) -> Void
+    let onAddServer: () -> Void
+    let onManageServers: () -> Void
+    let onOpenSettings: () -> Void
+
+    private var sortedHosts: [Host] {
+        hosts.sortedByDisplayName()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("BitDream")
+                .font(.title2.bold())
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .padding(.bottom, 4)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 2) {
+                    sectionHeader("Dreams")
+                    ForEach(SidebarSelection.allCases) { item in
+                        SidebarRow(
+                            title: item.rawValue,
+                            systemImage: item.icon,
+                            badge: torrentCount(item),
+                            isSelected: item == sidebarSelection
+                        ) {
+                            sidebarSelection = item
+                        }
+                    }
+
+                    sectionHeader("Servers")
+                    ForEach(sortedHosts, id: \.serverID) { host in
+                        SidebarRow(
+                            title: host.displayName,
+                            systemImage: "server.rack",
+                            showsCheckmark: host.serverID == selectedHostID
+                        ) {
+                            onSelectHost(host)
+                        }
+                    }
+                    SidebarRow(title: "Add Server", systemImage: "plus", action: onAddServer)
+                }
+                .padding(.horizontal, 8)
+            }
+            .contentMargins(.bottom, 60, for: .scrollContent)
+            .overlay(alignment: .bottom) {
+                HStack {
+                    FooterCircleButton(systemImage: "server.rack", label: "Manage Servers", action: onManageServers)
+
+                    Spacer()
+
+                    FooterCircleButton(systemImage: "gear", label: "Settings", action: onOpenSettings)
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background(Color(.systemBackground))
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 12)
+            .padding(.top, 16)
+            .padding(.bottom, 4)
+    }
+}
+
+private struct FooterCircleButton: View {
+    let systemImage: String
+    let label: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.title3)
+                .foregroundStyle(.primary)
+                .frame(width: 44, height: 44)
+                .background(
+                    Circle()
+                        .fill(Color(.systemBackground))
+                        .shadow(color: .black.opacity(0.18), radius: 8, y: 2)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+}
+
+private struct SidebarRow: View {
+    let title: String
+    let systemImage: String
+    var badge: Int?
+    var isSelected = false
+    var showsCheckmark = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .frame(width: 24)
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
+
+                Text(title)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer()
+
+                if showsCheckmark {
+                    Image(systemName: "checkmark")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.accentColor)
+                } else if let badge {
+                    Text("\(badge)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
+            )
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+#if DEBUG
+#Preview("iOS Sidebar") {
+    @Previewable @State var selection = SidebarSelection.allDreams
+    PreviewContainer { environment in
+        iOSSidebarView(
+            hosts: environment.hosts,
+            sidebarSelection: $selection,
+            selectedHostID: environment.hosts.first?.serverID,
+            torrentCount: { _ in 5 },
+            onSelectHost: { _ in },
+            onAddServer: {},
+            onManageServers: {},
+            onOpenSettings: {}
+        )
+        .frame(maxWidth: 300)
+    }
+}
+#endif
+
+#endif

--- a/BitDream/Views/iOS/iOSSidebarView.swift
+++ b/BitDream/Views/iOS/iOSSidebarView.swift
@@ -8,6 +8,7 @@ struct iOSSidebarView: View {
     let selectedHostID: String?
     let torrentCount: (SidebarSelection) -> Int
     let onSelectHost: (Host) -> Void
+    let onEditServer: (Host) -> Void
     let onAddServer: () -> Void
     let onManageServers: () -> Void
     let onOpenSettings: () -> Void
@@ -46,6 +47,14 @@ struct iOSSidebarView: View {
                             showsCheckmark: host.serverID == selectedHostID
                         ) {
                             onSelectHost(host)
+                        }
+                        .contextMenu {
+                            Button("Edit Server", systemImage: "square.and.pencil") {
+                                onEditServer(host)
+                            }
+                        }
+                        .accessibilityAction(named: "Edit Server") {
+                            onEditServer(host)
                         }
                     }
                     SidebarRow(
@@ -160,6 +169,7 @@ private struct SidebarRow: View {
             selectedHostID: environment.hosts.first?.serverID,
             torrentCount: { _ in 5 },
             onSelectHost: { _ in },
+            onEditServer: { _ in },
             onAddServer: {},
             onManageServers: {},
             onOpenSettings: {}

--- a/BitDream/Views/macOS/macOSContentSidebar.swift
+++ b/BitDream/Views/macOS/macOSContentSidebar.swift
@@ -41,7 +41,12 @@ struct macOSContentSidebar: View {
                 }
 
                 Button(action: onAddServer) {
-                    Label("Add Server", systemImage: "plus")
+                    Label {
+                        Text("Add Server")
+                    } icon: {
+                        Image(systemName: "plus.circle.fill")
+                            .foregroundStyle(accentColor)
+                    }
                 }
                 .buttonStyle(.plain)
             }

--- a/BitDream/Views/macOS/macOSContentSidebar.swift
+++ b/BitDream/Views/macOS/macOSContentSidebar.swift
@@ -9,6 +9,7 @@ struct macOSContentSidebar: View {
     let accentColor: Color
     let torrentCount: (SidebarSelection) -> Int
     let onSelectHost: (Host) -> Void
+    let onEditServer: (Host) -> Void
     let onAddServer: () -> Void
     let onManageServers: () -> Void
     let onOpenSettings: () -> Void
@@ -38,6 +39,22 @@ struct macOSContentSidebar: View {
                         }
                     }
                     .buttonStyle(.plain)
+                    .contextMenu {
+                        Button {
+                            onEditServer(host)
+                        } label: {
+                            Label {
+                                Text("Edit Server…")
+                            } icon: {
+                                Image(systemName: "square.and.pencil")
+                                    .symbolRenderingMode(.monochrome)
+                                    .foregroundStyle(.primary)
+                            }
+                        }
+                    }
+                    .accessibilityAction(named: "Edit Server") {
+                        onEditServer(host)
+                    }
                 }
 
                 Button(action: onAddServer) {
@@ -81,6 +98,7 @@ struct macOSContentSidebar: View {
         accentColor: .blue,
         torrentCount: { _ in 5 },
         onSelectHost: { _ in },
+        onEditServer: { _ in },
         onAddServer: {},
         onManageServers: {},
         onOpenSettings: {}

--- a/BitDream/Views/macOS/macOSContentView.swift
+++ b/BitDream/Views/macOS/macOSContentView.swift
@@ -9,6 +9,7 @@ struct macOSContentView: View {
     @Environment(\.openSettings) private var openSettings
     @Environment(\.openWindow) private var openWindow
     @EnvironmentObject private var themeManager: ThemeManager
+    @EnvironmentObject private var serverEditingCoordinator: MacOSServerEditingCoordinator
     let hosts: [Host]
     @ObservedObject var store: TransmissionStore
     private let userDefaults: UserDefaults
@@ -201,6 +202,10 @@ struct macOSContentView: View {
             onSelectHost: { host in
                 store.setHost(host: host)
                 selectedTorrentIds.removeAll()
+            },
+            onEditServer: { host in
+                serverEditingCoordinator.requestEditing(host)
+                openWindow(id: "manage-servers")
             },
             onAddServer: {
                 store.setup.toggle()

--- a/BitDream/Views/macOS/macOSServerList.swift
+++ b/BitDream/Views/macOS/macOSServerList.swift
@@ -150,15 +150,37 @@ private enum MacOSServerListAlert {
     }
 }
 
+@MainActor
+final class MacOSServerEditingCoordinator: ObservableObject {
+    struct Request: Equatable {
+        let id = UUID()
+        let serverID: String
+    }
+
+    @Published private(set) var request: Request?
+
+    func requestEditing(_ host: Host) {
+        request = Request(serverID: host.serverID)
+    }
+
+    func consume(_ handledRequest: Request) {
+        guard request?.id == handledRequest.id else { return }
+        request = nil
+    }
+}
+
 /// Root view for the Manage Servers auxiliary window.
 struct macOSManageServersWindow: View {
     @EnvironmentObject var store: TransmissionStore
+    @EnvironmentObject private var serverEditingCoordinator: MacOSServerEditingCoordinator
     @Query(sort: \Host.name, order: .forward) private var hosts: [Host]
 
     var body: some View {
         macOSServerList(
             hosts: hosts,
-            store: store
+            store: store,
+            editRequest: serverEditingCoordinator.request,
+            onEditRequestHandled: serverEditingCoordinator.consume
         )
     }
 }
@@ -167,6 +189,8 @@ struct macOSServerList: View {
     @Environment(\.hostRepositoryProvider) private var hostRepositoryProvider
     let hosts: [Host]
     @ObservedObject var store: TransmissionStore
+    let editRequest: MacOSServerEditingCoordinator.Request?
+    let onEditRequestHandled: (MacOSServerEditingCoordinator.Request) -> Void
 
     @State private var editorNavigation = MacOSServerEditorNavigationState()
     @State private var isSaving = false
@@ -244,9 +268,20 @@ struct macOSServerList: View {
         } message: {
             Text(dismissalConfirmationMessage)
         }
-        .onAppear(perform: syncSelection)
+        .onAppear {
+            syncSelection()
+            selectRequestedServer()
+        }
         .onChange(of: hosts.map(\.serverID)) { _, _ in
             syncSelection()
+        }
+        .onChange(of: editRequest) { _, _ in
+            selectRequestedServer()
+        }
+        .onChange(of: isSaving) { wasSaving, isSaving in
+            if wasSaving, !isSaving {
+                selectRequestedServer()
+            }
         }
     }
 }
@@ -399,6 +434,25 @@ private extension macOSServerList {
         )
     }
 
+    private func selectRequestedServer() {
+        guard let editRequest else { return }
+        guard hosts.contains(where: { $0.serverID == editRequest.serverID }) else {
+            onEditRequestHandled(editRequest)
+            return
+        }
+
+        let destination = MacOSServerEditorNavigationState.Destination.server(editRequest.serverID)
+        if editorNavigation.currentDestination == destination {
+            onEditRequestHandled(editRequest)
+            return
+        }
+
+        let result = requestTransition(to: destination)
+        if result != .ignored {
+            onEditRequestHandled(editRequest)
+        }
+    }
+
     private func startCreatingServer() {
         requestTransition(to: .newServer)
     }
@@ -480,11 +534,15 @@ private extension macOSServerList {
         return "Your unsaved server changes will be lost."
     }
 
-    private func requestTransition(to destination: MacOSServerEditorNavigationState.Destination) {
+    @discardableResult
+    private func requestTransition(
+        to destination: MacOSServerEditorNavigationState.Destination
+    ) -> MacOSServerEditorNavigationState.TransitionRequestResult {
         let result = editorNavigation.requestTransition(to: destination, whileSaving: isSaving)
         if result == .confirmationRequired {
             activeAlert = .discardChanges
         }
+        return result
     }
 
     private func confirmDiscardAndTransition() {
@@ -532,7 +590,12 @@ private extension macOSServerList {
 #if os(macOS) && DEBUG
 #Preview("macOS Server List", traits: .fixedLayout(width: 900, height: 600)) {
     PreviewContainer { environment in
-        macOSServerList(hosts: environment.hosts, store: environment.store)
+        macOSServerList(
+            hosts: environment.hosts,
+            store: environment.store,
+            editRequest: nil,
+            onEditRequestHandled: { _ in }
+        )
     }
 }
 #endif

--- a/BitDreamTests/Views/MacOSServerEditorNavigationStateTests.swift
+++ b/BitDreamTests/Views/MacOSServerEditorNavigationStateTests.swift
@@ -3,6 +3,23 @@ import XCTest
 
 #if os(macOS)
 final class MacOSServerEditorNavigationStateTests: XCTestCase {
+    @MainActor
+    func testEditingCoordinatorConsumesOnlyTheHandledRequest() throws {
+        let coordinator = MacOSServerEditingCoordinator()
+        let hosts = PreviewFixtures.makeHosts()
+
+        coordinator.requestEditing(hosts[0])
+        let staleRequest = try XCTUnwrap(coordinator.request)
+        coordinator.requestEditing(hosts[1])
+        let currentRequest = try XCTUnwrap(coordinator.request)
+
+        coordinator.consume(staleRequest)
+        XCTAssertEqual(coordinator.request, currentRequest)
+
+        coordinator.consume(currentRequest)
+        XCTAssertNil(coordinator.request)
+    }
+
     func testDirtyTransitionRequiresConfirmationBeforeChangingSelection() {
         var state = MacOSServerEditorNavigationState()
         state.apply(.server("server-a"))


### PR DESCRIPTION
## What Changed

- Replaced the iOS toolbar-button navigation with a slide-out sidebar drawer mirroring the macOS sidebar: Dreams status filters with badges, Servers with active checkmark and Add Server, and floating footer buttons for Manage Servers and Settings.
- The main screen slides right as a full-height rounded card when the drawer opens, fading behind a progressive background-colored scrim; drawer opens via the toolbar toggle or edge swipe, closes via card tap/swipe or selection. Sheets present over the open drawer.
- Sidebar selection now drives status filtering, so the Filter & Sort popover holds only label filters and sorting.
- Removed the server-rack and gear toolbar buttons (now in the sidebar); moved the Pause/Resume All menu to top-trailing.
- The sidebar toggle is a custom two-line glyph rendered as a template image so toolbar tinting matches SF Symbols, including the dimmed state during sheet transitions.

## Why

Bring the iOS navigation to parity with the macOS sidebar (status filters, server switching, settings access in one place) with a drawer interaction suited to the phone.

## Validation

- Full unit test suite passes (206 tests, 0 failures)
- Exercised on iPhone 17 Pro simulator (iOS 26.5) and iPhone 15 Pro device: drawer open/close via button, edge swipe, and card tap; status filter selection; server switching; sheets presenting over the open drawer
- macOS build verified unaffected

## UI Changes

New iOS drawer: 75%-width sidebar, main content as full-height rounded card with soft shadow, white floating footer circles aligned with the card's bottom toolbar.

<p align="center">
  <img width="45%" alt="iOS sidebar drawer" src="https://github.com/user-attachments/assets/8ab0dab3-2e6c-44af-9243-574e696625cd" />
  <img width="45%" alt="iOS sidebar drawer on device" src="https://github.com/user-attachments/assets/1606c91a-754f-4345-907d-77e9a137025b" />
</p>
