### PR TITLE
Improve the iOS Add Torrent interface

### DIFF
--- a/BitDream/Views/iOS/iOSAddTorrent.swift
+++ b/BitDream/Views/iOS/iOSAddTorrent.swift
@@ -12,29 +12,44 @@ struct iOSAddTorrent: View {
     @State private var downloadDir: String = ""
     @State private var errorMessage: String?
     @State private var showingError = false
+    @State private var isAdding = false
+    @FocusState private var isSourceFocused: Bool
+
+    private var trimmedInput: String {
+        alertInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isAddDisabled: Bool {
+        trimmedInput.isEmpty || isAdding
+    }
 
     // MARK: - Body
     var body: some View {
-        NavigationView {
+        NavigationStack {
             addTorrentForm
-                .navigationBarTitle(Text("Add Torrent"), displayMode: .inline)
+                .navigationTitle("Add Torrent")
+                .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        Button(action: {
-                            dismiss()
-                        }, label: {
-                            Text("Cancel")
-                        })
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel", action: dismiss.callAsFunction)
+                            .disabled(isAdding)
                     }
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button("Add") {
-                            submitMagnetTorrent()
+
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button(action: submitMagnetTorrent) {
+                            if isAdding {
+                                ProgressView()
+                                    .accessibilityLabel("Adding torrent")
+                            } else {
+                                Text("Add")
+                            }
                         }
                         .keyboardShortcut(.defaultAction)
-                        .disabled(alertInput.isEmpty)
+                        .disabled(isAddDisabled)
                     }
                 }
         }
+        .interactiveDismissDisabled(isAdding)
         .alert("Error", isPresented: $showingError, actions: {
             Button("OK", role: .cancel) {}
         }, message: {
@@ -45,35 +60,56 @@ struct iOSAddTorrent: View {
     // MARK: - Form View
     var addTorrentForm: some View {
         Form {
-            // Torrent Source Section
-            Section(header: Text("Torrent Source")) {
-                TextField("Magnet link or URL", text: $alertInput)
-                    .textFieldStyle(.roundedBorder)
-                    .autocapitalization(.none)
-                    .disableAutocorrection(true)
-                    .submitLabel(.done)
-                    .onSubmit {
-                        submitMagnetTorrent()
-                    }
+            Section {
+                HStack(spacing: 12) {
+                    Image(systemName: "link")
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+
+                    TextField("magnet:?xt=urn:btih:…", text: $alertInput)
+                        .keyboardType(.URL)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .focused($isSourceFocused)
+                        .submitLabel(.go)
+                        .onSubmit(submitMagnetTorrent)
+                }
+            } header: {
+                Text("Magnet Link")
             }
 
-            // Download Location Section
-            Section(header: Text("Download Location")) {
-                TextField("Download path", text: $downloadDir)
-                    .textFieldStyle(.roundedBorder)
-                    .autocapitalization(.none)
-                    .disableAutocorrection(true)
+            Section {
+                HStack(spacing: 12) {
+                    Image(systemName: "folder")
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+
+                    TextField("Download path", text: $downloadDir)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+            } header: {
+                Text("Download To")
             }
         }
+        .formStyle(.grouped)
+        .scrollDismissesKeyboard(.interactively)
+        .disabled(isAdding)
         .onAppear {
             downloadDir = store.defaultDownloadDir
+        }
+        .task {
+            isSourceFocused = true
         }
     }
 
     // MARK: - Actions
 
     private func submitMagnetTorrent() {
-        guard !alertInput.isEmpty else { return }
+        guard !isAddDisabled else { return }
+
+        isAdding = true
+        alertInput = trimmedInput
 
         performTransmissionAction(
             operation: {
@@ -83,9 +119,11 @@ struct iOSAddTorrent: View {
                 )
             },
             onSuccess: { (_: TransmissionTorrentAddOutcome) in
+                isAdding = false
                 dismiss()
             },
             onError: { message in
+                isAdding = false
                 presentAddTorrentSheetError(
                     detail: message,
                     errorMessage: $errorMessage,

--- a/BitDream/Views/iOS/iOSAddTorrent.swift
+++ b/BitDream/Views/iOS/iOSAddTorrent.swift
@@ -113,17 +113,17 @@ struct iOSAddTorrent: View {
 
         performTransmissionAction(
             operation: {
-                try await store.addTorrent(
+                defer { isAdding = false }
+
+                return try await store.addTorrent(
                     magnetLink: alertInput,
                     saveLocation: downloadDir
                 )
             },
             onSuccess: { (_: TransmissionTorrentAddOutcome) in
-                isAdding = false
                 dismiss()
             },
             onError: { message in
-                isAdding = false
                 presentAddTorrentSheetError(
                     detail: message,
                     errorMessage: $errorMessage,

--- a/BitDream/Views/macOS/macOSAddTorrent.swift
+++ b/BitDream/Views/macOS/macOSAddTorrent.swift
@@ -214,7 +214,7 @@ private extension macOSAddTorrent {
 
     var downloadLocationSection: some View {
         VStack(alignment: .leading) {
-            Text("Download Location")
+            Text("Download To")
                 .font(.headline)
                 .foregroundColor(.primary)
 


### PR DESCRIPTION
## What Changed

- Redesigned the iOS Add Torrent form with clearer magnet-link input, native grouped styling, icons, autofocus, and submission progress feedback.
- Trimmed the submitted magnet link and disabled dismissal while a submission is in progress.
- Aligned the download destination heading to “Download To” on iOS and macOS.

## Why

The iOS Add Torrent screen needed clearer terminology, a more native hierarchy, and better feedback during submission. The small macOS copy adjustment keeps the destination label consistent across platforms.

## Validation

- `swiftlint lint --quiet`
- iOS Debug build for `generic/platform=iOS` with code signing disabled
- macOS Debug build for `generic/platform=macOS`

## UI Changes

The iOS form now identifies the source as a magnet link, uses a representative placeholder, and presents the download destination consistently as “Download To.”
