### PR TITLE
Polish drawer open state and transition

### DIFF
--- a/BitDream/Views/iOS/iOSContentView.swift
+++ b/BitDream/Views/iOS/iOSContentView.swift
@@ -8,6 +8,7 @@ enum iOSNavigationRoute: Hashable {
 
 struct iOSContentView: View {
     @Environment(\.hapticFeedback) private var hapticFeedback
+    @Environment(\.colorScheme) private var colorScheme
 
     let hosts: [Host]
     @ObservedObject var store: TransmissionStore
@@ -157,17 +158,18 @@ private extension iOSContentView {
             hapticFeedback.play(.selectionChanged)
         }
         .overlay {
-            if progress > 0 {
-                // White scrim fades the card toward the background; also catches taps/drags to close
-                Color(.systemBackground)
-                    .opacity(0.55 * progress)
-                    .ignoresSafeArea()
-                    .contentShape(.rect)
-                    .onTapGesture {
-                        closeSidebar()
-                    }
-                    .gesture(closeDragGesture(drawerWidth: drawerWidth))
-            }
+            // Scrim doubles as elevation: light mode fades the card toward white,
+            // dark mode lifts it to a slightly lighter surface; also catches taps/drags to close.
+            // Always present (opacity-only changes) — structural insertion would render it at the
+            // animation's destination instead of riding the card.
+            (colorScheme == .dark ? Color(white: 0.2) : Color(.systemBackground))
+                .opacity(0.55 * progress)
+                .contentShape(.rect)
+                .onTapGesture {
+                    closeSidebar()
+                }
+                .gesture(closeDragGesture(drawerWidth: drawerWidth))
+                .allowsHitTesting(progress > 0)
         }
         .overlay(alignment: .leading) {
             if !isSidebarOpen && navigationPath.isEmpty {
@@ -178,13 +180,9 @@ private extension iOSContentView {
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 32 * progress, style: .continuous))
-        .overlay(
-            // Shadows vanish on black backgrounds; this edge keeps the card separated in dark mode
-            RoundedRectangle(cornerRadius: 32 * progress, style: .continuous)
-                .strokeBorder(Color(.separator).opacity(Double(progress)), lineWidth: 1)
-        )
         .shadow(color: .black.opacity(0.12 * progress), radius: 12)
         .offset(x: drawerWidth * progress)
+        .geometryGroup()
     }
 
     func openDragGesture(drawerWidth: CGFloat) -> some Gesture {
@@ -346,8 +344,10 @@ private extension iOSContentView {
             Button {
                 toggleSidebar()
             } label: {
+                // Bar glyphs ghost harder than the scrim alone while the drawer is open
                 SidebarToggleGlyph()
             }
+            .tint(Color.primary.opacity(isSidebarOpen && colorScheme == .light ? 0.5 : 1))
             .accessibilityLabel("Menu")
         }
     }
@@ -363,6 +363,7 @@ private extension iOSContentView {
                 })
             } label: {
                 Image(systemName: "ellipsis.circle")
+                    .foregroundStyle(Color.primary.opacity(isSidebarOpen && colorScheme == .light ? 0.5 : 1))
             }
             .iOSHapticControlActivation()
         }


### PR DESCRIPTION
## What Changed

- Fixed the drawer open/close transition: the card scrim is now permanently in the view tree with opacity-only changes, and the card subtree animates as one geometric unit via `geometryGroup()`. Previously the scrim was inserted structurally when the drawer opened, which rendered it at the animation's destination while the card slid underneath, producing visibly detached layers mid-transition.
- Dark mode open state: replaced the black dim and 1pt edge stroke with a mid-gray veil (`Color(white: 0.2)` at the same 55% strength as light mode) that lifts the card to an elevated surface and dims its content in a single overlay.
- Top-bar glyphs now fade to half alpha while the drawer is open in light mode, applied through tint/foreground-style alpha since the toolbar's template renderer discards plain view opacity. Dark mode keeps full-strength glyphs, which read correctly under the veil.

## Why

The initial drawer implementation shipped with a broken open/close transition and a dark-mode open state that lost all layer separation. These were found while comparing both appearances against the design target after merge.

## Validation

- Transition verified frame-by-frame: recorded the simulator during scripted open/close cycles, extracted frames with ffmpeg, and confirmed the card surface, nav bar items, banner, and scrim stay attached through every frame in both directions
- Open-state fade levels pixel-measured in both appearances (glyph at 197/255 in light, 143/255 in dark, matching the design target)
- iOS build clean; exercised on iPhone 17 Pro simulator in light and dark mode against a live Transmission server

## UI Changes

Drawer open state only: dark mode gains an elevated-gray card veil instead of a black dim, light mode top-bar glyphs ghost while open, and the open/close animation no longer shows detached layers.