### PR TITLE
Use native Liquid Glass for sidebar footer buttons

### DIFF
--- a/BitDream/Views/iOS/iOSSidebarView.swift
+++ b/BitDream/Views/iOS/iOSSidebarView.swift
@@ -68,12 +68,14 @@ struct iOSSidebarView: View {
             }
             .contentMargins(.bottom, 60, for: .scrollContent)
             .overlay(alignment: .bottom) {
-                HStack {
-                    FooterCircleButton(systemImage: "server.rack", label: "Manage Servers", action: onManageServers)
+                GlassEffectContainer {
+                    HStack {
+                        FooterCircleButton(systemImage: "server.rack", label: "Manage Servers", action: onManageServers)
 
-                    Spacer()
+                        Spacer()
 
-                    FooterCircleButton(systemImage: "gear", label: "Settings", action: onOpenSettings)
+                        FooterCircleButton(systemImage: "gear", label: "Settings", action: onOpenSettings)
+                    }
                 }
                 .padding(.horizontal, 16)
             }
@@ -101,17 +103,11 @@ private struct FooterCircleButton: View {
         Button(action: action) {
             Image(systemName: systemImage)
                 .font(.title3)
-                .foregroundStyle(.primary)
                 .frame(width: 44, height: 44)
-                .background(
-                    // Tertiary stays white in light mode but elevates to gray in dark,
-                    // where shadows alone can't separate the circle from the sidebar
-                    Circle()
-                        .fill(Color(.tertiarySystemBackground))
-                        .shadow(color: .black.opacity(0.18), radius: 8, y: 2)
-                )
+                .contentShape(.circle)
         }
         .buttonStyle(.plain)
+        .glassEffect(.regular.interactive(), in: .circle)
         .accessibilityLabel(label)
     }
 }


### PR DESCRIPTION
## Problem
The sidebar footer buttons (Manage Servers, Settings) had no press feedback and didn't behave like native glass buttons. The "glass" was a hand-painted `Circle().fill(Color(.tertiarySystemBackground))` with a manual drop shadow, and `.buttonStyle(.plain)` opted out of all system press feedback — so taps were visually dead.

## Fix
Replace the fake material with the native Liquid Glass API:
- `.glassEffect(.regular.interactive(), in: .circle)` on a 44×44 label — `.interactive()` provides the native press shimmer/scale
- Both buttons wrapped in a `GlassEffectContainer` per Apple guidance for multiple glass elements
- Manual shadow removed; the material handles dark-mode separation itself

The 44pt explicit size matches system toolbar item metrics (the main view's bottom-bar buttons), since standalone glass button styles don't hit that metric at any control size (regular ≈ 32pt, large ≈ 50pt).

## Verification
Built and ran on an iPhone 17 Pro simulator (iOS 26.5), screenshotted the open drawer, and measured cropped regions: footer buttons and the native bottom-bar filter button both measure ~130px (≈44pt @3x) with matching icon proportions.
