### PR TITLE
Prune stale appcast entries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,7 +473,7 @@ jobs:
             --download-url-prefix "$DOWNLOAD_PREFIX" \
             --link "$RELEASE_LINK" \
             --maximum-deltas 0 \
-            --maximum-versions 0 \
+            --maximum-versions 1 \
             "$APPCAST_WORK_DIR" | tee "$RUNNER_TEMP/generate-appcast.log"
 
           cp "$APPCAST_WORK_DIR/appcast.xml" "$PAGES_DIR/appcast.xml"


### PR DESCRIPTION
## What Changed

- Limit Sparkle appcast generation to the newest version for each update branch point.

## Why

The current release workflow preserves every historical appcast item. Deleted prerelease assets therefore remain advertised with download URLs that return 404. Pruning older entries when generating the next release leaves users with a valid update path.

## Validation

- Parsed `.github/workflows/release.yml` successfully as YAML.
- Ran `git diff --check origin/main...HEAD`.