### PR TITLE
Standardize bundle identifiers and bump version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
 
           APP_PROFILE_PLIST="$RUNNER_TEMP/BitDream-App.plist"
           WIDGET_PROFILE_PLIST="$RUNNER_TEMP/BitDream-Widget.plist"
-          REQUIRED_APP_GROUP="group.crapshack.BitDream"
+          REQUIRED_APP_GROUP="group.com.crapshack.BitDream"
 
           security cms -D -i "$APP_PROFILE_PATH" > "$APP_PROFILE_PLIST"
           security cms -D -i "$WIDGET_PROFILE_PATH" > "$WIDGET_PROFILE_PLIST"
@@ -203,9 +203,9 @@ jobs:
             <string>Developer ID Application</string>
             <key>provisioningProfiles</key>
             <dict>
-              <key>crapshack.BitDream</key>
+              <key>com.crapshack.BitDream</key>
               <string>$APP_PROFILE_UUID</string>
-              <key>crapshack.BitDream.BitDreamWidgets</key>
+              <key>com.crapshack.BitDream.BitDreamWidgets</key>
               <string>$WIDGET_PROFILE_UUID</string>
             </dict>
           </dict>

--- a/BitDream.xcodeproj/project.pbxproj
+++ b/BitDream.xcodeproj/project.pbxproj
@@ -503,7 +503,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = crapshack.BitDream;
+				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.BitDream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -553,7 +553,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = crapshack.BitDream;
+				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.BitDream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "BitDream App Developer ID";
 				REGISTER_APP_GROUPS = YES;
@@ -591,7 +591,7 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = crapshack.BitDream.BitDreamWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.BitDream.BitDreamWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -637,7 +637,7 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = crapshack.BitDream.BitDreamWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.BitDream.BitDreamWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "BitDream Widget Developer ID";
 				REGISTER_APP_GROUPS = YES;
@@ -669,7 +669,7 @@
 					"@loader_path/../../../../MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				PRODUCT_BUNDLE_IDENTIFIER = crapshack.BitDreamTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.BitDreamTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -695,7 +695,7 @@
 					"@loader_path/../../../../MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				PRODUCT_BUNDLE_IDENTIFIER = crapshack.BitDreamTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.BitDreamTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/BitDream.xcodeproj/project.pbxproj
+++ b/BitDream.xcodeproj/project.pbxproj
@@ -502,7 +502,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.BitDream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -552,7 +552,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.BitDream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "BitDream App Developer ID";
@@ -590,7 +590,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.BitDream.BitDreamWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -636,7 +636,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.BitDream.BitDreamWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "BitDream Widget Developer ID";

--- a/BitDream/BitDream.entitlements
+++ b/BitDream/BitDream.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.crapshack.BitDream</string>
+		<string>group.com.crapshack.BitDream</string>
 	</array>
 </dict>
 </plist>

--- a/BitDream/Widgets/AppGroup.swift
+++ b/BitDream/Widgets/AppGroup.swift
@@ -6,7 +6,7 @@ import OSLog
 
 enum AppGroup {
     /// App Group identifier shared by the app and widget extension
-    static let identifier: String = "group.crapshack.BitDream"
+    static let identifier: String = "group.com.crapshack.BitDream"
 
     /// Container URL for the shared App Group
     static func containerURL() -> URL? {

--- a/BitDream/Widgets/README.md
+++ b/BitDream/Widgets/README.md
@@ -6,7 +6,7 @@
 - Data is supplied from the host app through a lightweight snapshot written to a shared App Group container.
 
 ### Key Components
-- App Group: `group.crapshack.BitDream`
+- App Group: `group.com.crapshack.BitDream`
   - Shared container for widget snapshots and a server index file.
   - No credentials are stored in the widget extension.
 - App Intents
@@ -33,7 +33,7 @@
 
 ### iOS Background Refresh (by the book)
 - Capability: Background Modes → Background fetch (enabled on iOS target).
-- Scheduler: `BGTaskScheduler` with identifier `crapshack.BitDream.refresh`.
+- Scheduler: `BGTaskScheduler` with identifier `com.crapshack.BitDream.refresh`.
 - Flow:
   - Register on app launch.
   - Schedule on launch and when entering background.
@@ -56,7 +56,7 @@
   - iOS app target
   - macOS app target
   - Widget extension target
-- iOS only: Add `BGTaskSchedulerPermittedIdentifiers` to Info.plist with `crapshack.BitDream.refresh`.
+- iOS only: Add `BGTaskSchedulerPermittedIdentifiers` to Info.plist with `com.crapshack.BitDream.refresh`.
  - macOS widget extension: Enable App Sandbox capability (required for the extension to load/show on macOS).
 
 ### Performance and Budgeting

--- a/BitDreamWidgets/BitDreamWidgetsExtension.entitlements
+++ b/BitDreamWidgets/BitDreamWidgetsExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.crapshack.BitDream</string>
+		<string>group.com.crapshack.BitDream</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## What Changed

- Updated the app, widget extension, and test bundle identifiers to the `com.crapshack.BitDream` namespace.
- Updated the shared App Group and background refresh identifier.
- Updated Developer ID profile mappings and App Group validation in the release workflow.
- Updated widget documentation to match the new identifiers.
- Bumped the app and widget marketing version to `2.0.2`.

## Why

Standardize BitDream’s Apple identifiers under the conventional reverse-domain namespace and prepare version 2.0.2. This intentionally establishes new application and App Group identities; data associated with the previous identifiers is not migrated.

## Validation

- macOS Debug build with code signing disabled
- iOS Debug compile check with code signing disabled
- macOS test suite: 223 tests passed
- SwiftLint
- Property-list and entitlement validation
- Xcode build settings resolve marketing version 2.0.2
- Regenerated Developer ID profiles verified against the new Bundle IDs and App Group