### PR TITLE
Silence unused result warnings for refresh outcome methods

### DIFF
--- a/BitDream/TransmissionStore.swift
+++ b/BitDream/TransmissionStore.swift
@@ -680,10 +680,11 @@ extension TransmissionStore {
     func requestRefresh() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            _ = await self.refreshNow()
+            await self.refreshNow()
         }
     }
 
+    @discardableResult
     func refreshNow() async -> RefreshOutcome {
         guard let activeConnection else { return .unavailable }
 
@@ -775,6 +776,7 @@ extension TransmissionStore {
         }
     }
 
+    @discardableResult
     private func performFullRefresh(for connectionState: ActiveConnection) async -> RefreshOutcome {
         do {
             let snapshot = try await connectionState.connection.fetchAppRefreshSnapshot()

--- a/BitDream/Views/Shared/TorrentDetailSupplementalStore+Bindings.swift
+++ b/BitDream/Views/Shared/TorrentDetailSupplementalStore+Bindings.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @MainActor
 extension TorrentDetailSupplementalStore {
+    @discardableResult
     func load(
         for identity: TorrentDetailIdentity,
         using store: TransmissionStore,
@@ -66,6 +67,7 @@ extension TorrentDetailSupplementalStore {
         )
     }
 
+    @discardableResult
     func loadIfIdle(
         for identity: TorrentDetailIdentity,
         using store: TransmissionStore,


### PR DESCRIPTION
## What Changed

Marked five `RefreshOutcome`-returning methods `@discardableResult`:

- `TransmissionStore.refreshNow()` and `TransmissionStore.performFullRefresh(for:)`
- The `Binding`-based `load(for:using:showingError:errorMessage:)` and `loadIfIdle(for:using:showingError:errorMessage:)` wrappers on `TorrentDetailSupplementalStore`

Also removed the now-redundant `_ =` discard in `TransmissionStore.requestRefresh()`.

## Why

Xcode reported six "Result of call to '…' is unused" warnings across `macOSContentView`, `macOSTorrentDetail`, and `TransmissionStore`. These methods exist primarily for their side effects and surface errors internally via `onError` handlers and error bindings, so most call sites legitimately ignore the returned `RefreshOutcome`. Per SE-0047's guidance (and the SE-0520 precedent that made `Task` initializers discardable for fire-and-forget use), the API author should annotate such methods rather than sprinkle `_ =` at every call site. Callers that want the outcome — iOS pull-to-refresh haptics and the test suite — still receive it.

The core `onError`-variant `load`/`loadIfIdle` on `TorrentDetailSupplementalStore` remain unannotated since their callers all consume the result, keeping the warning as a guardrail there.

## Validation

- `BitDreamAppStore` Debug macOS build is clean: all six warnings resolved, no new warnings
- Full macOS test suite (`BitDream` scheme) passes: `** TEST SUCCEEDED **`
- `swiftlint lint --quiet` reports no violations