### PR TITLE
Disable Sparkle updater in debug builds

### DIFF
--- a/BitDream/AppUpdater.swift
+++ b/BitDream/AppUpdater.swift
@@ -28,6 +28,9 @@ final class AppUpdater: NSObject, ObservableObject {
 
     init(updatesEnabled: Bool = true) {
         super.init()
+        #if DEBUG
+        return
+        #else
         guard updatesEnabled else { return }
 
         updaterController = SPUStandardUpdaterController(
@@ -37,6 +40,7 @@ final class AppUpdater: NSObject, ObservableObject {
         )
         observeUpdaterState()
         refreshState()
+        #endif
     }
 
     func start() {


### PR DESCRIPTION
## What Changed

`AppUpdater.init` returns early under `#if DEBUG` before creating the `SPUStandardUpdaterController`, so debug builds never start Sparkle or check the appcast. The class already handles the no-updater state (`canCheckForUpdates` stays false; the Settings UI takes the same path previews use via `AppUpdater(updatesEnabled: false)`). Release builds are unchanged.

## Why

Local Xcode builds carry the placeholder `CFBundleVersion` of 1 — the release workflow stamps the real build number only in CI. Sparkle compares `CFBundleVersion` against the appcast's `sparkle:version`, so every debug build looks older than any published release, producing a bogus downgrade prompt (e.g. "BitDream 2.0.2 is now available—you have 2.0.3"). Dev builds shouldn't self-update from the public feed at all.

## Validation

- Debug configuration builds clean (`xcodebuild -scheme BitDream -configuration Debug`).
- Release configuration compiles clean with `CODE_SIGNING_ALLOWED=NO` (this machine lacks the Developer ID cert; unrelated to the change).
- Verified the trigger: a local Debug build's Info.plist reports `CFBundleShortVersionString 2.0.3` / `CFBundleVersion 1`, while the published appcast advertises `sparkle:version 2.0.2`.