### PR TITLE
Add GitHub link to About page

### DIFF
--- a/BitDream/BitDreamApp.swift
+++ b/BitDream/BitDreamApp.swift
@@ -305,7 +305,7 @@ private extension BitDreamApp {
                 .navigationTitle("About BitDream")  // Proper window title handling
                 .environmentObject(themeManager)
                 .immediateTheme(manager: themeManager)
-                .frame(width: 320, height: 400)
+                .frame(width: 320)
         }
         .windowResizability(.contentSize)
         .defaultPosition(.center)

--- a/BitDream/Views/iOS/Settings/iOSAboutView.swift
+++ b/BitDream/Views/iOS/Settings/iOSAboutView.swift
@@ -62,6 +62,15 @@ struct iOSAboutView: View {
                         .padding(.top, 12)
                 }
 
+                Button("GitHub") {
+                    hapticFeedback.play(.actionTriggered)
+                    if let url = URL(string: "https://github.com/austin-smith/BitDream") {
+                        openURL(url)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
+
                 // Transmission Acknowledgment
                 VStack(spacing: 8) {
                     Divider()

--- a/BitDream/Views/macOS/macOSAboutView.swift
+++ b/BitDream/Views/macOS/macOSAboutView.swift
@@ -62,9 +62,17 @@ struct macOSAboutView: View {
                         .foregroundStyle(.tertiary)
                         .padding(.top, 12)
                 }
+
+                Button("GitHub") {
+                    if let url = URL(string: "https://github.com/austin-smith/BitDream") {
+                        openURL(url)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
             }
 
-            // Transmission Acknowledgment - cleaner integration
+            // Transmission Acknowledgment
             VStack(spacing: 8) {
                 Divider()
                     .padding(.horizontal, 24)


### PR DESCRIPTION
## What Changed
Added a bordered GitHub button to the About page on both platforms, linking to the project repository. The button sits after the version/copyright block, above the Transmission acknowledgment. The iOS button plays haptic feedback on tap, consistent with the existing Transmission link. Also removed a stale comment suffix in the macOS view.

The macOS About window previously used a hard-coded 320×400 frame that left no headroom for the new button; the height is now derived from content (`.frame(width: 320)` with the existing `.windowResizability(.contentSize)`), so the window always fits its content exactly.

## Why
Surface the project's source repository directly in the app, matching the About page pattern used in ComputerSolitaire.

## Validation
- `swiftlint lint --quiet` passes with no output
- macOS Debug build succeeds (`generic/platform=macOS`)
- iOS Debug build succeeds (`generic/platform=iOS`, `CODE_SIGNING_ALLOWED=NO`)
- Verified rendering in the macOS About window and on an iPhone 17 Pro simulator

## UI Changes
Both About views gain a bordered "GitHub" button between the copyright line and the divider. Layout order on both platforms: version, copyright, GitHub button, divider, "Powered by Transmission". The macOS About window now sizes its height to content.